### PR TITLE
Skip v1 suffix when using Ollama endpoints

### DIFF
--- a/Controllers/ArticleSummaryController.php
+++ b/Controllers/ArticleSummaryController.php
@@ -43,7 +43,8 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
 
     // 处理 $oai_url
     $oai_url = rtrim($oai_url, '/'); // 去除末尾的斜杠
-    if (!preg_match('/\/v\d+\/?$/', $oai_url)) {
+    // Ollama doesn't use versioned endpoints, so avoid appending /v1 for that provider
+    if ($oai_provider !== 'ollama' && !preg_match('/\/v\d+\/?$/', $oai_url)) {
         $oai_url .= '/v1'; // 如果没有版本信息，则添加 /v1 - If there is no version information, add /v1
     }
     // Open AI Input


### PR DESCRIPTION
## Summary
- avoid appending `/v1` version suffix when the selected provider is Ollama, which uses unversioned endpoints

## Testing
- `php -l Controllers/ArticleSummaryController.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5bc43e5e88321a9a657ce64062805