### PR TITLE
Handle non-stream OpenAI responses and fix summary visibility

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -126,6 +126,16 @@ async function sendOpenAIRequest(container, oaiParams) {
     while (true) {
       const { done, value } = await reader.read();
       if (done) {
+        if (buffer) {
+          try {
+            const json = JSON.parse(buffer.trim());
+            text += json.choices?.[0]?.message?.content || json.choices?.[0]?.delta?.content || '';
+            setOaiState(container, 0, null, marked.parse(text));
+          } catch (e) {
+            console.error('Error parsing final JSON:', e, 'Chunk:', buffer);
+            setOaiState(container, 2, '请求失败 / Request Failed', null);
+          }
+        }
         setOaiState(container, 0, 'finish', null);
         break;
       }

--- a/static/style.css
+++ b/static/style.css
@@ -11,6 +11,10 @@
   margin-bottom: 0.5em;
 }
 
+.oai-summary-content {
+  color: #000;
+}
+
 .oai-summary-content h1,
 .oai-summary-content h2,
 .oai-summary-content h3,


### PR DESCRIPTION
## Summary
- parse non-stream OpenAI responses so summaries replace the loading message
- ensure summary text renders in a readable color

## Testing
- `npm test` (fails: no package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a5dc7c647c8321b3f66edafe7e4caf