### PR TITLE
Fix summarize request encoding

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -63,15 +63,14 @@ async function summarizeButtonClick(target) {
 
   // 这是 php 获取参数的地址 - This is the address where PHP gets the parameters
   var url = target.dataset.request;
-  var data = {
-    ajax: true,
-    _csrf: context.csrf
-  };
+  var data = new URLSearchParams();
+  data.append('ajax', 'true');
+  data.append('_csrf', context.csrf);
 
   try {
     const response = await axios.post(url, data, {
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/x-www-form-urlencoded'
       }
     });
 


### PR DESCRIPTION
## Summary
- send summarize request as URL-encoded form data so FreshRSS parses CSRF token correctly

## Testing
- `node --check static/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5f22eba7c8321beaf34a5a4146b32