### PR TITLE
Avoid fatal error when DOM extension missing

### DIFF
--- a/Controllers/ArticleSummaryController.php
+++ b/Controllers/ArticleSummaryController.php
@@ -116,6 +116,11 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
 
   private function htmlToMarkdown($content)
   {
+    // Ensure DOM extension is available; otherwise fall back to plain text
+    if (!class_exists('DOMDocument') || !class_exists('DOMXPath')) {
+      return trim(strip_tags($content));
+    }
+
     // Creating DOMDocument objects
     $dom = new DOMDocument();
     libxml_use_internal_errors(true); // Ignore HTML parsing errors


### PR DESCRIPTION
## Summary
- Handle cases where PHP DOM extension is not installed
- Fallback to stripping HTML tags when DOMDocument or DOMXPath is unavailable

## Testing
- `php -l Controllers/ArticleSummaryController.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5f45154a48321bbafd61f67e991fc