### PR TITLE
feat: style summary button

### DIFF
--- a/extension.php
+++ b/extension.php
@@ -29,7 +29,7 @@ class ArticleSummaryExtension extends Minz_Extension
 
     $entry->_content(
       '<div class="oai-summary-wrap">'
-      . '<button data-request="' . $url_summary . '" class="oai-summary-btn"></button>'
+      . '<button data-request="' . $url_summary . '" class="oai-summary-btn btn btn-small" aria-label="Résumer" title="Résumer"><span class="icon icon-ellipsis"></span></button>'
       . '<div class="oai-summary-loader"></div>'
       . '<div class="oai-summary-log"></div>'
       . '<div class="oai-summary-content"></div>'

--- a/static/script.js
+++ b/static/script.js
@@ -7,11 +7,6 @@ if (document.readyState && document.readyState !== 'loading') {
 function configureSummarizeButtons() {
   document.getElementById('global').addEventListener('click', function (e) {
     for (var target = e.target; target && target != this; target = target.parentNode) {
-      
-      if (target.matches('.flux_header')) {
-        target.nextElementSibling.querySelector('.oai-summary-btn').innerHTML = 'Summarize'
-      }
-
       if (target.matches('.oai-summary-btn')) {
         e.preventDefault();
         e.stopPropagation();
@@ -49,8 +44,6 @@ function setOaiState(container, statusType, statusMsg, summaryText) {
       button.disabled = false;
     }
   }
-
-  console.log(content);
 
   if (summaryText) {
     content.innerHTML = summaryText;

--- a/static/style.css
+++ b/static/style.css
@@ -8,7 +8,6 @@
 }
 
 .oai-summary-btn {
-  font-size: 1.2em;
   margin-bottom: 1em;
 }
 


### PR DESCRIPTION
## Summary
- use ellipsis icon for summary button with accessible label
- remove fixed font size to adopt theme styling
- simplify JS click handler without innerHTML changes

## Testing
- `php -l extension.php`
- `node --check static/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8199e9494832184cbe21a6dd01762