### PR TITLE
Ensure summary styles inherit text color

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -14,7 +14,7 @@
 .oai-summary-log {
   font-size: 0.9em;
   margin-bottom: 1em;
-  color: var(--text-color);
+  color: inherit;
 }
 
 .oai-summary-loader {
@@ -38,7 +38,7 @@
 }
 
 .oai-summary-content {
-  color: var(--text-color);
+  color: inherit;
 }
 
 .oai-summary-content h1,


### PR DESCRIPTION
## Summary
- Let summary log inherit text color instead of using a fixed variable
- Allow summary content to inherit color for internal elements

## Testing
- `php -l extension.php`
- `php -l Controllers/ArticleSummaryController.php`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a81e47c1d8832199f9c605549d215f