### PR TITLE
feat: display summary icon on button

### DIFF
--- a/extension.php
+++ b/extension.php
@@ -30,7 +30,7 @@ class ArticleSummaryExtension extends Minz_Extension
       $entry->_content(
         '<div class="oai-summary-wrap">'
         . '<button data-request="' . $url_summary . '" class="oai-summary-btn btn btn-small" aria-label="Résumer" title="Résumer">'
-        . '<img src="' . $this->getFileUrl('summary.svg', 'img') . '" class="oai-summary-icon" alt="Résumé"></button>'
+        . '<img src="' . $this->getFileUrl('img/summary.svg') . '" class="oai-summary-icon" alt="Résumé"></button>'
         . '<div class="oai-summary-loader"></div>'
         . '<div class="oai-summary-log"></div>'
         . '<div class="oai-summary-content"></div>'

--- a/extension.php
+++ b/extension.php
@@ -27,15 +27,16 @@ class ArticleSummaryExtension extends Minz_Extension
       )
     ));
 
-    $entry->_content(
-      '<div class="oai-summary-wrap">'
-      . '<button data-request="' . $url_summary . '" class="oai-summary-btn btn btn-small" aria-label="Résumer" title="Résumer"><span class="icon icon-ellipsis"></span></button>'
-      . '<div class="oai-summary-loader"></div>'
-      . '<div class="oai-summary-log"></div>'
-      . '<div class="oai-summary-content"></div>'
-      . '</div>'
-      . $entry->content()
-    );
+      $entry->_content(
+        '<div class="oai-summary-wrap">'
+        . '<button data-request="' . $url_summary . '" class="oai-summary-btn btn btn-small" aria-label="Résumer" title="Résumer">'
+        . '<img src="' . $this->getFileUrl('summary.svg', 'img') . '" class="oai-summary-icon" alt="Résumé"></button>'
+        . '<div class="oai-summary-loader"></div>'
+        . '<div class="oai-summary-log"></div>'
+        . '<div class="oai-summary-content"></div>'
+        . '</div>'
+        . $entry->content()
+      );
     return $entry;
   }
 

--- a/static/img/summary.svg
+++ b/static/img/summary.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M4 5h16v2H4zm0 6h16v2H4zm0 6h10v2H4z"/>
+</svg>

--- a/static/style.css
+++ b/static/style.css
@@ -11,6 +11,11 @@
   margin-bottom: 1em;
 }
 
+.oai-summary-btn img {
+  width: 1em;
+  height: 1em;
+}
+
 .oai-summary-log {
   font-size: 0.9em;
   margin-bottom: 1em;


### PR DESCRIPTION
## Summary
- add dedicated summary.svg icon
- show SVG icon in summary button
- size button icon via CSS

## Testing
- `php -l extension.php`


------
https://chatgpt.com/codex/tasks/task_e_68a82272fcb883218bf863ad2d325bac