### PR TITLE
feat: add summary box container

### DIFF
--- a/extension.php
+++ b/extension.php
@@ -31,9 +31,11 @@ class ArticleSummaryExtension extends Minz_Extension
         '<div class="oai-summary-wrap">'
         . '<button data-request="' . $url_summary . '" class="oai-summary-btn btn btn-small" aria-label="Résumer" title="Résumer">'
         . '<img src="' . $this->getFileUrl('img/summary.svg') . '" class="oai-summary-icon" alt="Résumé"></button>'
+        . '<div class="oai-summary-box">'
         . '<div class="oai-summary-loader"></div>'
         . '<div class="oai-summary-log"></div>'
         . '<div class="oai-summary-content"></div>'
+        . '</div>'
         . '</div>'
         . $entry->content()
       );

--- a/static/style.css
+++ b/static/style.css
@@ -1,14 +1,12 @@
 .oai-summary-wrap {
-
-  background: var(--content-bg);
-  padding: 0.75em;
   margin-bottom: 1em;
-  border: 1px solid var(--border-color);
-  border-radius: 4px;
 }
 
-.oai-summary-btn {
-  margin-bottom: 1em;
+.oai-summary-box {
+  background: var(--header-bg);
+  border-radius: 8px;
+  padding: 0.75em;
+  margin-top: 1em;
 }
 
 .oai-summary-btn img {


### PR DESCRIPTION
## Summary
- wrap loader, log, and summary content in dedicated `.oai-summary-box`
- style new summary box and simplify outer wrapper margins

## Testing
- `php -l extension.php`


------
https://chatgpt.com/codex/tasks/task_e_68a82b9c1b388321b392bb8e3d46eeaf