### PR TITLE
Hide summary box until summary requested

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -56,6 +56,8 @@ async function summarizeButtonClick(target) {
     return;
   }
 
+  container.classList.add('oai-summary-active');
+
   setOaiState(container, 1, 'Preparing request...', null);
 
   // This is the address where PHP gets the parameters

--- a/static/style.css
+++ b/static/style.css
@@ -3,11 +3,20 @@
 }
 
 .oai-summary-box {
+  display: none;
   background: var(--frss-background-color-dark);
   color: var(--frss-font-color-light);
   border-radius: 8px;
   padding: 0.75em;
   margin-top: 1em;
+}
+
+.oai-summary-wrap.oai-summary-active .oai-summary-box {
+  display: block;
+}
+
+.oai-summary-wrap.oai-summary-active .oai-summary-btn {
+  display: none;
 }
 
 .oai-summary-btn img {


### PR DESCRIPTION
## Summary
- Hide the summary box by default and display it only after the summary button is clicked
- Remove the summary button after activation so only the summary content remains

## Testing
- `node --check static/script.js`
- `php -l extension.php`
- `php -l Controllers/ArticleSummaryController.php`


------
https://chatgpt.com/codex/tasks/task_e_68a834a2061c8321b507b554c104eb2d