### PR TITLE
Style log and hide indicators after summary

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -24,7 +24,13 @@ function setOaiState(container, statusType, statusMsg, summaryText) {
   const content = container.querySelector('.oai-summary-content');
   const log = container.querySelector('.oai-summary-log');
   if (statusMsg !== null) {
-    log.textContent = statusMsg;
+    if (statusMsg === 'finish') {
+      log.textContent = '';
+      log.style.display = 'none';
+    } else {
+      log.textContent = statusMsg;
+      log.style.display = 'block';
+    }
   }
   if (statusType === 1) {
     container.classList.add('oai-loading');
@@ -40,7 +46,6 @@ function setOaiState(container, statusType, statusMsg, summaryText) {
     container.classList.remove('oai-loading');
     container.classList.remove('oai-error');
     if (statusMsg === 'finish') {
-      log.textContent = '';
       button.disabled = false;
     }
   }

--- a/static/style.css
+++ b/static/style.css
@@ -25,9 +25,12 @@
 }
 
 .oai-summary-log {
+  display: none;
   font-size: 0.9em;
   margin-bottom: 1em;
   color: inherit;
+  font-style: italic;
+  text-align: center;
 }
 
 .oai-summary-loader {


### PR DESCRIPTION
## Summary
- center and italicize request log messages
- hide loader and log once summary completes to avoid leftover space

## Testing
- `node --check static/script.js`
- `php -l extension.php Controllers/ArticleSummaryController.php`


------
https://chatgpt.com/codex/tasks/task_e_68a83700d1b08321bb01a811bc28c09e