### PR TITLE
Add option for longer summaries with secondary prompt

### DIFF
--- a/Controllers/ArticleSummaryController.php
+++ b/Controllers/ArticleSummaryController.php
@@ -11,8 +11,11 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
     $oai_url = FreshRSS_Context::$user_conf->oai_url;
     $oai_key = FreshRSS_Context::$user_conf->oai_key;
     $oai_model = FreshRSS_Context::$user_conf->oai_model;
-    $oai_prompt = FreshRSS_Context::$user_conf->oai_prompt;
+    $oai_prompt_base = FreshRSS_Context::$user_conf->oai_prompt;
+    $oai_prompt_more = FreshRSS_Context::$user_conf->oai_prompt_2;
     $oai_provider = FreshRSS_Context::$user_conf->oai_provider;
+    $use_more = Minz_Request::param('more');
+    $oai_prompt = $use_more ? $oai_prompt_more : $oai_prompt_base;
 
     if (
       $this->isEmpty($oai_url)

--- a/configure.phtml
+++ b/configure.phtml
@@ -3,6 +3,7 @@ $oai_url = FreshRSS_Context::$user_conf->oai_url;
 $oai_key = FreshRSS_Context::$user_conf->oai_key;
 $oai_model = FreshRSS_Context::$user_conf->oai_model;
 $oai_prompt = FreshRSS_Context::$user_conf->oai_prompt;
+$oai_prompt_2 = FreshRSS_Context::$user_conf->oai_prompt_2;
 $oai_provider = FreshRSS_Context::$user_conf->oai_provider ?: 'openai'; // Default to OpenAI
 ?>
 
@@ -23,6 +24,8 @@ $oai_provider = FreshRSS_Context::$user_conf->oai_provider ?: 'openai'; // Defau
     <input type="text" name="oai_model" id="oai_model" value="<?php echo $oai_model; ?>">
     <label for="oai_prompt">Prompt (add before content)</label>
     <textarea name="oai_prompt" id="oai_prompt"><?php echo $oai_prompt; ?></textarea>
+    <label for="oai_prompt_2">Second prompt (longer summary)</label>
+    <textarea name="oai_prompt_2" id="oai_prompt_2"><?php echo $oai_prompt_2; ?></textarea>
   </div>
   <hr />
   <button type="submit">Save</button>

--- a/extension.php
+++ b/extension.php
@@ -26,6 +26,15 @@ class ArticleSummaryExtension extends Minz_Extension
         'id' => $entry->id()
       )
     ));
+    $url_more = Minz_Url::display(array(
+      'c' => 'ArticleSummary',
+      'a' => 'summarize',
+      'params' => array(
+        'id' => $entry->id(),
+        'more' => 1
+      )
+    ));
+    $has_more = !empty(FreshRSS_Context::$user_conf->oai_prompt_2);
 
       $entry->_content(
         '<div class="oai-summary-wrap">'
@@ -35,6 +44,7 @@ class ArticleSummaryExtension extends Minz_Extension
         . '<div class="oai-summary-loader"></div>'
         . '<div class="oai-summary-log"></div>'
         . '<div class="oai-summary-content"></div>'
+        . ($has_more ? '<button data-request="' . $url_more . '" class="oai-summary-btn oai-summary-more btn btn-small" aria-label="Résumé plus long" title="Résumé plus long">+</button>' : '')
         . '</div>'
         . '</div>'
         . $entry->content()
@@ -49,6 +59,7 @@ class ArticleSummaryExtension extends Minz_Extension
       FreshRSS_Context::$user_conf->oai_key = Minz_Request::param('oai_key', '');
       FreshRSS_Context::$user_conf->oai_model = Minz_Request::param('oai_model', '');
       FreshRSS_Context::$user_conf->oai_prompt = Minz_Request::param('oai_prompt', '');
+      FreshRSS_Context::$user_conf->oai_prompt_2 = Minz_Request::param('oai_prompt_2', '');
       FreshRSS_Context::$user_conf->oai_provider = Minz_Request::param('oai_provider', '');
       FreshRSS_Context::$user_conf->save();
     }

--- a/extension.php
+++ b/extension.php
@@ -34,21 +34,21 @@ class ArticleSummaryExtension extends Minz_Extension
         'more' => 1
       )
     ));
-    $has_more = !empty(FreshRSS_Context::$user_conf->oai_prompt_2);
+    $has_more = trim((string)FreshRSS_Context::$user_conf->oai_prompt_2) !== '';
 
-      $entry->_content(
-        '<div class="oai-summary-wrap">'
-        . '<button data-request="' . $url_summary . '" class="oai-summary-btn btn btn-small" aria-label="Résumer" title="Résumer">'
-        . '<img src="' . $this->getFileUrl('img/summary.svg') . '" class="oai-summary-icon" alt="Résumé"></button>'
-        . '<div class="oai-summary-box">'
-        . '<div class="oai-summary-loader"></div>'
-        . '<div class="oai-summary-log"></div>'
-        . '<div class="oai-summary-content"></div>'
-        . ($has_more ? '<button data-request="' . $url_more . '" class="oai-summary-btn oai-summary-more btn btn-small" aria-label="Résumé plus long" title="Résumé plus long">+</button>' : '')
-        . '</div>'
-        . '</div>'
-        . $entry->content()
-      );
+    $entry->_content(
+      '<div class="oai-summary-wrap">'
+      . '<button data-request="' . $url_summary . '" class="oai-summary-btn btn btn-small" aria-label="Résumer" title="Résumer">'
+      . '<img src="' . $this->getFileUrl('img/summary.svg') . '" class="oai-summary-icon" alt="Résumé"></button>'
+      . '<div class="oai-summary-box">'
+      . '<div class="oai-summary-loader"></div>'
+      . '<div class="oai-summary-log"></div>'
+      . '<div class="oai-summary-content"></div>'
+      . ($has_more ? '<button data-request="' . $url_more . '" class="oai-summary-btn oai-summary-more btn btn-small" aria-label="Résumé plus long" title="Résumé plus long">+</button>' : '')
+      . '</div>'
+      . '</div>'
+      . $entry->content()
+    );
     return $entry;
   }
 

--- a/static/script.js
+++ b/static/script.js
@@ -21,6 +21,7 @@ function configureSummarizeButtons() {
 
 function setOaiState(container, statusType, statusMsg, summaryText) {
   const button = container.querySelector('.oai-summary-btn');
+  const moreButton = container.querySelector('.oai-summary-more');
   const content = container.querySelector('.oai-summary-content');
   const log = container.querySelector('.oai-summary-log');
   if (statusMsg !== null) {
@@ -37,16 +38,19 @@ function setOaiState(container, statusType, statusMsg, summaryText) {
     container.classList.remove('oai-error');
     button.disabled = true;
     content.innerHTML = '';
+    if (moreButton) moreButton.style.display = 'none';
   } else if (statusType === 2) {
     container.classList.remove('oai-loading');
     container.classList.add('oai-error');
     button.disabled = false;
     content.innerHTML = '';
+    if (moreButton) moreButton.style.display = 'none';
   } else {
     container.classList.remove('oai-loading');
     container.classList.remove('oai-error');
     if (statusMsg === 'finish') {
       button.disabled = false;
+      if (moreButton) moreButton.style.display = 'inline-block';
     }
   }
 
@@ -56,7 +60,7 @@ function setOaiState(container, statusType, statusMsg, summaryText) {
 }
 
 async function summarizeButtonClick(target) {
-  var container = target.parentNode;
+  var container = target.closest('.oai-summary-wrap');
   if (container.classList.contains('oai-loading')) {
     return;
   }

--- a/static/style.css
+++ b/static/style.css
@@ -68,3 +68,8 @@
   padding: 0;
   margin: 0;
 }
+
+.oai-summary-more {
+  display: none;
+  margin-top: 1em;
+}


### PR DESCRIPTION
## Summary
- allow storing a second, longer summary prompt in extension configuration
- render a "+" button to regenerate a longer summary once initial summary is produced
- update JavaScript and styles to handle the new button and prompt selection

## Testing
- `php -l extension.php`
- `php -l Controllers/ArticleSummaryController.php`
- `php -l configure.phtml`
- `node --check static/script.js && echo 'syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68a8386e113883218b8bba00296c0220