### PR TITLE
Fix plus summary button visibility

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -15,7 +15,9 @@
   display: block;
 }
 
-.oai-summary-wrap.oai-summary-active .oai-summary-btn {
+/* Hide only the top-level summarize button when the wrapper is active,
+   keeping nested buttons such as the “+” button visible. */
+.oai-summary-wrap.oai-summary-active > .oai-summary-btn {
   display: none;
 }
 


### PR DESCRIPTION
## Summary
- Ensure the nested "+" button remains visible when showing article summaries

## Testing
- `php -l extension.php Controllers/ArticleSummaryController.php`

------
https://chatgpt.com/codex/tasks/task_e_68a83aebeb3c8321bc380d7297dbd5ed