### PR TITLE
Handle 'more' summary button

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -50,7 +50,14 @@ function setOaiState(container, statusType, statusMsg, summaryText) {
     container.classList.remove('oai-error');
     if (statusMsg === 'finish') {
       button.disabled = false;
-      if (moreButton) moreButton.style.display = 'inline-block';
+      if (container.dataset.moreUsed) {
+        if (moreButton) {
+          moreButton.remove();
+        }
+        delete container.dataset.moreUsed;
+      } else if (moreButton) {
+        moreButton.style.display = 'inline-block';
+      }
     }
   }
 
@@ -63,6 +70,10 @@ async function summarizeButtonClick(target) {
   var container = target.closest('.oai-summary-wrap');
   if (container.classList.contains('oai-loading')) {
     return;
+  }
+
+  if (target.classList.contains('oai-summary-more')) {
+    container.dataset.moreUsed = '1';
   }
 
   container.classList.add('oai-summary-active');


### PR DESCRIPTION
## Summary
- Track when the "More" button is used by setting a `moreUsed` flag on the summary container.
- When the summary request finishes, remove the "More" button if the flag is set and clear the flag; otherwise show the button normally.

## Testing
- `node --check static/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8712d3be88321a94f7b4e807cd12b