### PR TITLE
Color summarize button icon with theme variable

### DIFF
--- a/extension.php
+++ b/extension.php
@@ -36,10 +36,12 @@ class ArticleSummaryExtension extends Minz_Extension
     ));
     $has_more = trim((string)FreshRSS_Context::$user_conf->oai_prompt_2) !== '';
 
+    $icon = str_replace('<svg ', '<svg class="oai-summary-icon" ', file_get_contents(__DIR__ . '/static/img/summary.svg'));
+
     $entry->_content(
       '<div class="oai-summary-wrap">'
       . '<button data-request="' . $url_summary . '" class="oai-summary-btn btn btn-small" aria-label="Résumer" title="Résumer">'
-      . '<img src="' . $this->getFileUrl('img/summary.svg') . '" class="oai-summary-icon" alt="Résumé"></button>'
+      . $icon . '</button>'
       . '<div class="oai-summary-box">'
       . '<div class="oai-summary-loader"></div>'
       . '<div class="oai-summary-log"></div>'

--- a/static/style.css
+++ b/static/style.css
@@ -21,9 +21,10 @@
   display: none;
 }
 
-.oai-summary-btn img {
+.oai-summary-btn .oai-summary-icon {
   width: 1em;
   height: 1em;
+  color: var(--frss-font-color-light);
 }
 
 .oai-summary-log {


### PR DESCRIPTION
## Summary
- tint summarize button icon using the theme's light font color variable
- inline SVG icon for color styling

## Testing
- `php -l extension.php`
- `php -l configure.phtml`


------
https://chatgpt.com/codex/tasks/task_e_68a9cc4ec1d8832195b6e1a32c7f67a7