### PR TITLE
Switch to gpt-5-nano Responses API

### DIFF
--- a/Controllers/ArticleSummaryController.php
+++ b/Controllers/ArticleSummaryController.php
@@ -55,24 +55,23 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
       'response' => array(
         'data' => array(
           // Determine whether the URL ends with a version. If it does, no version information is added. If not, /v1 is added by default.
-          "oai_url" => $oai_url . '/chat/completions',
+          "oai_url" => $oai_url . '/responses',
           "oai_key" => $oai_key,
-          "model" => $oai_model,
-          "messages" => [
+          "model" => 'gpt-5-nano',
+          "input" => [
             [
               "role" => "system",
               "content" => $oai_prompt
+            ],
+            [
+              "role" => "user",
+              "content" => "input: \n" . $content,
+            ]
           ],
-          [
-            "role" => "user",
-            "content" => "input: \n" . $content,
-          ]
-        ],
-        "reasoning": { "effort": "minimal" },
-        "verbosity": "low",
-        "max_completion_tokens" => 2048, // You can adjust the length of the summary as needed.
-        "temperature" => 1, // gpt-5-nano expects 1
-        "n" => 1 // Generate summary
+          "reasoning" => [ "effort" => "minimal" ],
+          "max_output_tokens" => 2048, // You can adjust the length of the summary as needed.
+          "temperature" => 1, // gpt-5-nano expects 1
+          "stream" => true
       ),
       'provider' => 'openai',
       'error' => null

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To configure the extension, follow these steps:
 
 1. **Base URL**: Enter the base URL of your language model API (e.g., `https://api.openai.com/`). Note that the URL should not include the version path (e.g., `/v1`).
 2. **API Key**: Provide your API key for authentication.
-3. **Model Name**: Specify the model name you wish to use for summarization (e.g., `gpt-3.5-turbo`).
+3. **Model Name**: Specify the model name you wish to use for summarization (e.g., `gpt-5-nano`).
 4. **Prompt**: Add a prompt that will be included before the article content when sending the request to the API.
 
 ## Usage


### PR DESCRIPTION
## Summary
- Call OpenAI's gpt-5-nano model via the new `responses` endpoint with minimal reasoning
- Adapt frontend streaming parser for Responses API
- Document gpt-5-nano model usage in configuration instructions

## Testing
- `php -l Controllers/ArticleSummaryController.php`
- `node --check static/script.js && echo 'ok'`


------
https://chatgpt.com/codex/tasks/task_e_68a9dda0d33c8321bbb11dd8d6879fea