### PR TITLE
Use configured model for OpenAI requests

### DIFF
--- a/Controllers/ArticleSummaryController.php
+++ b/Controllers/ArticleSummaryController.php
@@ -57,7 +57,7 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
           // Determine whether the URL ends with a version. If it does, no version information is added. If not, /v1 is added by default.
           "oai_url" => $oai_url . '/responses',
           "oai_key" => $oai_key,
-          "model" => 'gpt-5-nano',
+          "model" => $oai_model,
           "input" => [
             [
               "role" => "system",

--- a/tests/ArticleSummaryControllerTest.php
+++ b/tests/ArticleSummaryControllerTest.php
@@ -1,0 +1,56 @@
+<?php
+error_reporting(E_ERROR);
+require __DIR__ . '/../Controllers/ArticleSummaryController.php';
+
+// Stub classes and functions required by the controller
+class Minz_ActionController {}
+class FreshRSS_Context { public static $user_conf; }
+class Minz_Request {
+    public static function param($name) {
+        return null; // No 'more' or 'id' parameter needed for this test
+    }
+}
+class FreshRSS_Factory {
+    public static function createEntryDao() {
+        return new class {
+            public function searchById($id) {
+                return new class {
+                    public function content() {
+                        return 'Example content';
+                    }
+                };
+            }
+        };
+    }
+}
+
+// Set up configuration with a specific model name
+FreshRSS_Context::$user_conf = (object) [
+    'oai_url' => 'https://api.example.com',
+    'oai_key' => 'test-key',
+    'oai_model' => 'my-configured-model',
+    'oai_prompt' => 'prompt',
+    'oai_prompt_2' => 'prompt2',
+    'oai_provider' => 'openai',
+];
+
+// Capture the output of summarizeAction()
+ob_start();
+$controller = new FreshExtension_ArticleSummary_Controller();
+$controller->view = new class {
+    public function _layout($layout) {}
+};
+$controller->summarizeAction();
+$output = ob_get_clean();
+
+// Decode the JSON response
+$data = json_decode($output, true);
+$model = $data['response']['data']['model'] ?? null;
+
+// Simple assertion
+if ($model !== 'my-configured-model') {
+    echo "Model mismatch: expected my-configured-model, got {$model}\n";
+    exit(1);
+}
+
+echo "Model matches configuration\n";


### PR DESCRIPTION
## Summary
- use configured `$oai_model` when building OpenAI request
- add test ensuring the controller uses the configured model

## Testing
- `php tests/ArticleSummaryControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9e6b9d87c83218d84f199589a9d1d