### PR TITLE
feat: add text-to-speech button

### DIFF
--- a/extension.php
+++ b/extension.php
@@ -36,10 +36,12 @@ class ArticleSummaryExtension extends Minz_Extension
     ));
     $has_more = trim((string)FreshRSS_Context::$user_conf->oai_prompt_2) !== '';
 
+    $icon_tts = str_replace('<svg ', '<svg class="oai-tts-icon" ', file_get_contents(__DIR__ . '/static/img/play.svg'));
     $icon = str_replace('<svg ', '<svg class="oai-summary-icon" ', file_get_contents(__DIR__ . '/static/img/summary.svg'));
 
     $entry->_content(
       '<div class="oai-summary-wrap">'
+      . '<button class="oai-tts-btn btn btn-small" aria-label="Lire" title="Lire">' . $icon_tts . '</button>'
       . '<button data-request="' . $url_summary . '" class="oai-summary-btn btn btn-small" aria-label="Résumer" title="Résumer">'
       . $icon . '</button>'
       . '<div class="oai-summary-box">'

--- a/static/img/play.svg
+++ b/static/img/play.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M8 5v14l11-7z"/>
+</svg>

--- a/static/style.css
+++ b/static/style.css
@@ -1,5 +1,13 @@
 .oai-summary-wrap {
   margin-bottom: 1em;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5em;
+}
+
+.oai-summary-wrap > .oai-summary-box {
+  flex-basis: 100%;
 }
 
 .oai-summary-box {
@@ -22,6 +30,12 @@
 }
 
 .oai-summary-btn .oai-summary-icon {
+  width: 1em;
+  height: 1em;
+  color: var(--frss-font-color-light);
+}
+
+.oai-tts-btn .oai-tts-icon {
   width: 1em;
   height: 1em;
   color: var(--frss-font-color-light);


### PR DESCRIPTION
## Summary
- add play icon and TTS button before summary action
- style wrapper to align TTS and summary buttons

## Testing
- `phpunit tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2be5e514832187c0f7697fb4ee1c