### PR TITLE
Add TTS playback support

### DIFF
--- a/Controllers/ArticleSummaryController.php
+++ b/Controllers/ArticleSummaryController.php
@@ -101,6 +101,54 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
     return;
   }
 
+  public function fetchTtsParamsAction()
+  {
+    $this->view->_layout(false);
+    header('Content-Type: application/json');
+
+    $oai_url = FreshRSS_Context::$user_conf->oai_url;
+    $oai_key = FreshRSS_Context::$user_conf->oai_key;
+    $tts_model = FreshRSS_Context::$user_conf->oai_tts_model;
+    $tts_voice = FreshRSS_Context::$user_conf->oai_tts_voice;
+
+    if (
+      $this->isEmpty($oai_url) ||
+      $this->isEmpty($oai_key) ||
+      $this->isEmpty($tts_model) ||
+      $this->isEmpty($tts_voice)
+    ) {
+      echo json_encode(array(
+        'response' => array(
+          'data' => 'missing config',
+          'error' => 'configuration'
+        ),
+        'status' => 200
+      ));
+      return;
+    }
+
+    $oai_url = rtrim($oai_url, '/');
+    if (!preg_match('/\/v\d+\/?$/', $oai_url)) {
+      $oai_url .= '/v1';
+    }
+
+    $successResponse = array(
+      'response' => array(
+        'data' => array(
+          'oai_url' => $oai_url,
+          'oai_key' => $oai_key,
+          'model' => $tts_model,
+          'voice' => $tts_voice,
+        ),
+        'error' => null
+      ),
+      'status' => 200
+    );
+
+    echo json_encode($successResponse);
+    return;
+  }
+
   private function isEmpty($item)
   {
     return $item === null || trim($item) === '';

--- a/extension.php
+++ b/extension.php
@@ -36,12 +36,16 @@ class ArticleSummaryExtension extends Minz_Extension
     ));
     $has_more = trim((string)FreshRSS_Context::$user_conf->oai_prompt_2) !== '';
 
+    $url_tts = Minz_Url::display(array(
+      'c' => 'ArticleSummary',
+      'a' => 'fetchTtsParams'
+    ));
     $icon_tts = str_replace('<svg ', '<svg class="oai-tts-icon" ', file_get_contents(__DIR__ . '/static/img/play.svg'));
     $icon = str_replace('<svg ', '<svg class="oai-summary-icon" ', file_get_contents(__DIR__ . '/static/img/summary.svg'));
 
     $entry->_content(
       '<div class="oai-summary-wrap">'
-      . '<button class="oai-tts-btn btn btn-small" aria-label="Lire" title="Lire">' . $icon_tts . '</button>'
+      . '<button data-request="' . $url_tts . '" class="oai-tts-btn btn btn-small" aria-label="Lire" title="Lire">' . $icon_tts . '</button>'
       . '<button data-request="' . $url_summary . '" class="oai-summary-btn btn btn-small" aria-label="Résumer" title="Résumer">'
       . $icon . '</button>'
       . '<div class="oai-summary-box">'
@@ -65,6 +69,8 @@ class ArticleSummaryExtension extends Minz_Extension
       FreshRSS_Context::$user_conf->oai_prompt = Minz_Request::param('oai_prompt', '');
       FreshRSS_Context::$user_conf->oai_prompt_2 = Minz_Request::param('oai_prompt_2', '');
       FreshRSS_Context::$user_conf->oai_provider = Minz_Request::param('oai_provider', '');
+      FreshRSS_Context::$user_conf->oai_tts_model = Minz_Request::param('oai_tts_model', '');
+      FreshRSS_Context::$user_conf->oai_tts_voice = Minz_Request::param('oai_tts_voice', '');
       FreshRSS_Context::$user_conf->save();
     }
   }

--- a/tests/ArticleSummaryControllerTest.php
+++ b/tests/ArticleSummaryControllerTest.php
@@ -32,6 +32,8 @@ FreshRSS_Context::$user_conf = (object) [
     'oai_prompt' => 'prompt',
     'oai_prompt_2' => 'prompt2',
     'oai_provider' => 'openai',
+    'oai_tts_model' => 'my-tts-model',
+    'oai_tts_voice' => 'my-voice',
 ];
 
 // Capture the output of summarizeAction()
@@ -54,3 +56,17 @@ if ($model !== 'my-configured-model') {
 }
 
 echo "Model matches configuration\n";
+
+// Test fetchTtsParamsAction()
+ob_start();
+$controller->fetchTtsParamsAction();
+$ttsOutput = ob_get_clean();
+$ttsData = json_decode($ttsOutput, true);
+$voice = $ttsData['response']['data']['voice'] ?? null;
+
+if ($voice !== 'my-voice') {
+    echo "Voice mismatch: expected my-voice, got {$voice}\n";
+    exit(1);
+}
+
+echo "Voice matches configuration\n";


### PR DESCRIPTION
## Summary
- add configurable TTS button and endpoint to fetch audio parameters
- handle `.oai-tts-btn` in client script and stream audio from OpenAI
- extend tests for TTS config retrieval

## Testing
- `php tests/ArticleSummaryControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa2d73cf9c83219d9356ab9f410548