### PR TITLE
feat: add server endpoint for text-to-speech

### DIFF
--- a/Controllers/ArticleSummaryController.php
+++ b/Controllers/ArticleSummaryController.php
@@ -101,6 +101,58 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
     return;
   }
 
+  public function speakAction()
+  {
+    $this->view->_layout(false);
+    header('Content-Type: application/json');
+
+    $oai_url = FreshRSS_Context::$user_conf->oai_url;
+    $oai_key = FreshRSS_Context::$user_conf->oai_key;
+    $tts_model = FreshRSS_Context::$user_conf->oai_tts_model;
+    $tts_voice = FreshRSS_Context::$user_conf->oai_tts_voice;
+    $content = Minz_Request::param('content');
+
+    if (
+      $this->isEmpty($oai_url) ||
+      $this->isEmpty($oai_key) ||
+      $this->isEmpty($tts_model) ||
+      $this->isEmpty($tts_voice) ||
+      $this->isEmpty($content)
+    ) {
+      echo json_encode(array(
+        'response' => array(
+          'data' => 'missing config',
+          'error' => 'configuration'
+        ),
+        'status' => 200
+      ));
+      return;
+    }
+
+    $oai_url = rtrim($oai_url, '/');
+    if (!preg_match('/\/v\d+\/?$/', $oai_url)) {
+      $oai_url .= '/v1';
+    }
+
+    $successResponse = array(
+      'response' => array(
+        'data' => array(
+          'oai_url' => $oai_url . '/audio/speech',
+          'oai_key' => $oai_key,
+          'model' => $tts_model,
+          'voice' => $tts_voice,
+          'input' => $content,
+        ),
+        'provider' => 'openai',
+        'error' => null
+      ),
+      'status' => 200
+    );
+
+    echo json_encode($successResponse);
+    return;
+  }
+
   public function fetchTtsParamsAction()
   {
     $this->view->_layout(false);

--- a/extension.php
+++ b/extension.php
@@ -38,7 +38,7 @@ class ArticleSummaryExtension extends Minz_Extension
 
     $url_tts = Minz_Url::display(array(
       'c' => 'ArticleSummary',
-      'a' => 'fetchTtsParams'
+      'a' => 'speak'
     ));
     $icon_tts = str_replace('<svg ', '<svg class="oai-tts-icon" ', file_get_contents(__DIR__ . '/static/img/play.svg'));
     $icon = str_replace('<svg ', '<svg class="oai-summary-icon" ', file_get_contents(__DIR__ . '/static/img/summary.svg'));

--- a/static/script.js
+++ b/static/script.js
@@ -138,6 +138,7 @@ async function ttsButtonClick(target) {
   const data = new URLSearchParams();
   data.append('ajax', 'true');
   data.append('_csrf', context.csrf);
+  data.append('content', text);
 
   target.disabled = true;
   log.textContent = 'Preparing audio...';
@@ -159,10 +160,10 @@ async function ttsButtonClick(target) {
     const body = {
       model: params.model,
       voice: params.voice,
-      input: text
+      input: params.input
     };
 
-    const audioResp = await fetch(params.oai_url + '/audio/speech', {
+    const audioResp = await fetch(params.oai_url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/tests/ArticleSummaryControllerTest.php
+++ b/tests/ArticleSummaryControllerTest.php
@@ -6,8 +6,9 @@ require __DIR__ . '/../Controllers/ArticleSummaryController.php';
 class Minz_ActionController {}
 class FreshRSS_Context { public static $user_conf; }
 class Minz_Request {
+    public static $params = [];
     public static function param($name) {
-        return null; // No 'more' or 'id' parameter needed for this test
+        return self::$params[$name] ?? null; // No 'more' or 'id' parameter needed for this test
     }
 }
 class FreshRSS_Factory {
@@ -70,3 +71,18 @@ if ($voice !== 'my-voice') {
 }
 
 echo "Voice matches configuration\n";
+
+// Test speakAction()
+Minz_Request::$params = ['content' => 'Speak me'];
+ob_start();
+$controller->speakAction();
+$speakOutput = ob_get_clean();
+$speakData = json_decode($speakOutput, true);
+$input = $speakData['response']['data']['input'] ?? null;
+
+if ($input !== 'Speak me') {
+    echo "Input mismatch: expected Speak me, got {$input}\n";
+    exit(1);
+}
+
+echo "Speak action returns input\n";


### PR DESCRIPTION
## Summary
- add `speakAction` to deliver text-to-speech parameters and content
- wire play button and frontend script to new endpoint
- extend tests for TTS flow

## Testing
- `php tests/ArticleSummaryControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa3010bc1c8321b2e0ec3381f98c61