### PR TITLE
Add configurable TTS voice and model

### DIFF
--- a/Controllers/ArticleSummaryController.php
+++ b/Controllers/ArticleSummaryController.php
@@ -109,14 +109,14 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
     $oai_url = FreshRSS_Context::$user_conf->oai_url;
     $oai_key = FreshRSS_Context::$user_conf->oai_key;
     $tts_model = FreshRSS_Context::$user_conf->oai_tts_model;
-    $tts_voice = FreshRSS_Context::$user_conf->oai_tts_voice;
+    $voice = FreshRSS_Context::$user_conf->oai_voice;
     $content = Minz_Request::param('content');
 
     if (
       $this->isEmpty($oai_url) ||
       $this->isEmpty($oai_key) ||
       $this->isEmpty($tts_model) ||
-      $this->isEmpty($tts_voice) ||
+      $this->isEmpty($voice) ||
       $this->isEmpty($content)
     ) {
       echo json_encode(array(
@@ -140,7 +140,7 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
           'oai_url' => $oai_url . '/audio/speech',
           'oai_key' => $oai_key,
           'model' => $tts_model,
-          'voice' => $tts_voice,
+          'voice' => $voice,
           'input' => $content,
         ),
         'provider' => 'openai',
@@ -161,13 +161,13 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
     $oai_url = FreshRSS_Context::$user_conf->oai_url;
     $oai_key = FreshRSS_Context::$user_conf->oai_key;
     $tts_model = FreshRSS_Context::$user_conf->oai_tts_model;
-    $tts_voice = FreshRSS_Context::$user_conf->oai_tts_voice;
+    $voice = FreshRSS_Context::$user_conf->oai_voice;
 
     if (
       $this->isEmpty($oai_url) ||
       $this->isEmpty($oai_key) ||
       $this->isEmpty($tts_model) ||
-      $this->isEmpty($tts_voice)
+      $this->isEmpty($voice)
     ) {
       echo json_encode(array(
         'response' => array(
@@ -190,7 +190,7 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
           'oai_url' => $oai_url,
           'oai_key' => $oai_key,
           'model' => $tts_model,
-          'voice' => $tts_voice,
+          'voice' => $voice,
         ),
         'error' => null
       ),

--- a/configure.phtml
+++ b/configure.phtml
@@ -2,6 +2,8 @@
 $oai_url   = FreshRSS_Context::$user_conf->oai_url   ?: 'https://api.openai.com';
 $oai_key = FreshRSS_Context::$user_conf->oai_key;
 $oai_model = FreshRSS_Context::$user_conf->oai_model ?: 'gpt-5-nano';
+$oai_tts_model = FreshRSS_Context::$user_conf->oai_tts_model ?: 'gpt-tts-1';
+$oai_voice = FreshRSS_Context::$user_conf->oai_voice ?: 'alloy';
 $oai_prompt = FreshRSS_Context::$user_conf->oai_prompt;
 $oai_prompt_2 = FreshRSS_Context::$user_conf->oai_prompt_2;
 $oai_provider = FreshRSS_Context::$user_conf->oai_provider ?: 'openai'; // Default to OpenAI
@@ -22,6 +24,10 @@ $oai_provider = FreshRSS_Context::$user_conf->oai_provider ?: 'openai'; // Defau
     <input type="text" name="oai_key" id="oai_key" value="<?php echo $oai_key; ?>">
     <label for="oai_model">Model Name</label>
     <input type="text" name="oai_model" id="oai_model" value="<?php echo $oai_model; ?>">
+    <label for="oai_voice">Voix</label>
+    <input type="text" name="oai_voice" id="oai_voice" value="<?php echo $oai_voice; ?>">
+    <label for="oai_tts_model">Modèle TTS</label>
+    <input type="text" name="oai_tts_model" id="oai_tts_model" value="<?php echo $oai_tts_model; ?>">
     <label for="oai_prompt">Prompt (add before content)</label>
     <textarea name="oai_prompt" id="oai_prompt"><?php echo $oai_prompt; ?></textarea>
     <label for="oai_prompt_2">Second prompt (longer summary)</label>

--- a/extension.php
+++ b/extension.php
@@ -70,7 +70,7 @@ class ArticleSummaryExtension extends Minz_Extension
       FreshRSS_Context::$user_conf->oai_prompt_2 = Minz_Request::param('oai_prompt_2', '');
       FreshRSS_Context::$user_conf->oai_provider = Minz_Request::param('oai_provider', '');
       FreshRSS_Context::$user_conf->oai_tts_model = Minz_Request::param('oai_tts_model', '');
-      FreshRSS_Context::$user_conf->oai_tts_voice = Minz_Request::param('oai_tts_voice', '');
+      FreshRSS_Context::$user_conf->oai_voice = Minz_Request::param('oai_voice', '');
       FreshRSS_Context::$user_conf->save();
     }
   }

--- a/tests/ArticleSummaryControllerTest.php
+++ b/tests/ArticleSummaryControllerTest.php
@@ -34,7 +34,7 @@ FreshRSS_Context::$user_conf = (object) [
     'oai_prompt_2' => 'prompt2',
     'oai_provider' => 'openai',
     'oai_tts_model' => 'my-tts-model',
-    'oai_tts_voice' => 'my-voice',
+    'oai_voice' => 'my-voice',
 ];
 
 // Capture the output of summarizeAction()


### PR DESCRIPTION
## Summary
- add default voice and TTS model options to configuration view
- store voice and TTS model preferences in user settings
- align controller and tests with new `oai_voice` field

## Testing
- `php tests/ArticleSummaryControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa3185d38c83219ee82c0ea5d2160b