### PR TITLE
Handle article content for TTS

### DIFF
--- a/extension.php
+++ b/extension.php
@@ -44,20 +44,20 @@ class ArticleSummaryExtension extends Minz_Extension
     $icon_tts_pause = str_replace('<svg ', '<svg class="oai-tts-icon oai-tts-pause" ', file_get_contents(__DIR__ . '/static/img/pause.svg'));
     $icon = str_replace('<svg ', '<svg class="oai-summary-icon" ', file_get_contents(__DIR__ . '/static/img/summary.svg'));
 
-    $entry->_content(
-      '<div class="oai-summary-wrap">'
-      . '<button data-request="' . $url_tts . '" class="oai-tts-btn btn btn-small" aria-label="Lire" title="Lire">' . $icon_tts_play . $icon_tts_pause . '</button>'
-      . '<button data-request="' . $url_summary . '" class="oai-summary-btn btn btn-small" aria-label="Résumer" title="Résumer">'
-      . $icon . '</button>'
-      . '<div class="oai-summary-box">'
-      . '<div class="oai-summary-loader"></div>'
-      . '<div class="oai-summary-log"></div>'
-      . '<div class="oai-summary-content"></div>'
-      . ($has_more ? '<button data-request="' . $url_more . '" class="oai-summary-btn oai-summary-more btn btn-small" aria-label="Résumé plus long" title="Résumé plus long">+</button>' : '')
-      . '</div>'
-      . '</div>'
-      . $entry->content()
-    );
+      $entry->_content(
+        '<div class="oai-summary-wrap">'
+        . '<button data-request="' . $url_tts . '" class="oai-tts-btn btn btn-small" aria-label="Lire" title="Lire">' . $icon_tts_play . $icon_tts_pause . '</button>'
+        . '<button data-request="' . $url_summary . '" class="oai-summary-btn btn btn-small" aria-label="Résumer" title="Résumer">'
+        . $icon . '</button>'
+        . '<div class="oai-summary-box">'
+        . '<div class="oai-summary-loader"></div>'
+        . '<div class="oai-summary-log"></div>'
+        . '<div class="oai-summary-content"></div>'
+        . ($has_more ? '<button data-request="' . $url_more . '" class="oai-summary-btn oai-summary-more btn btn-small" aria-label="Résumé plus long" title="Résumé plus long">+</button>' : '')
+        . '</div>'
+        . '<div class="oai-summary-article">' . $entry->content() . '</div>'
+        . '</div>'
+      );
     return $entry;
   }
 

--- a/static/script.js
+++ b/static/script.js
@@ -145,7 +145,8 @@ async function ttsButtonClick(target) {
 
   const container = target.closest('.oai-summary-wrap');
   const log = container.querySelector('.oai-summary-log');
-  const text = container.querySelector('.oai-summary-content').textContent.trim();
+  const article = container.querySelector('.oai-summary-article');
+  const text = article ? article.textContent.trim() : '';
   if (!text) {
     return;
   }

--- a/static/style.css
+++ b/static/style.css
@@ -10,6 +10,10 @@
   flex-basis: 100%;
 }
 
+.oai-summary-wrap > .oai-summary-article {
+  flex-basis: 100%;
+}
+
 .oai-summary-box {
   display: none;
   background: var(--frss-background-color-dark);


### PR DESCRIPTION
## Summary
- Wrap article markup in `.oai-summary-article` so TTS can access full text
- Read article content instead of summary in `ttsButtonClick`
- Ensure article block fills width of summary wrapper

## Testing
- `php tests/ArticleSummaryControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa370326c08321a82e7b3b88c3a618