### PR TITLE
Enable streaming text-to-speech with abort support

### DIFF
--- a/Controllers/ArticleSummaryController.php
+++ b/Controllers/ArticleSummaryController.php
@@ -142,6 +142,7 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
           'model' => $tts_model,
           'voice' => $voice,
           'input' => $content,
+          'stream' => true,
         ),
         'provider' => 'openai',
         'error' => null

--- a/static/script.js
+++ b/static/script.js
@@ -127,7 +127,10 @@ async function summarizeButtonClick(target) {
 }
 
 async function ttsButtonClick(target) {
-  // Toggle play/pause if audio already loaded
+  const container = target.closest('.oai-summary-wrap');
+  const log = container.querySelector('.oai-summary-log');
+
+  // Toggle play/pause or cancel if audio already loaded
   if (target._audio) {
     if (target._audio.paused) {
       target._audio.play();
@@ -135,7 +138,17 @@ async function ttsButtonClick(target) {
       target.setAttribute('aria-label', 'Pause');
       target.setAttribute('title', 'Pause');
     } else {
-      target._audio.pause();
+      if (target._abortController) {
+        target._abortController.abort();
+        target._abortController = null;
+        URL.revokeObjectURL(target._audio.src);
+        target._audio.pause();
+        target._audio = null;
+        log.textContent = '';
+        log.style.display = 'none';
+      } else {
+        target._audio.pause();
+      }
       target.classList.remove('oai-playing');
       target.setAttribute('aria-label', 'Lire');
       target.setAttribute('title', 'Lire');
@@ -143,8 +156,6 @@ async function ttsButtonClick(target) {
     return;
   }
 
-  const container = target.closest('.oai-summary-wrap');
-  const log = container.querySelector('.oai-summary-log');
   const article = container.querySelector('.oai-summary-article');
   const text = article ? article.textContent.trim() : '';
   if (!text) {
@@ -177,8 +188,12 @@ async function ttsButtonClick(target) {
     const body = {
       model: params.model,
       voice: params.voice,
-      input: params.input
+      input: params.input,
+      stream: params.stream
     };
+
+    const controller = new AbortController();
+    target._abortController = controller;
 
     const audioResp = await fetch(params.oai_url, {
       method: 'POST',
@@ -186,15 +201,17 @@ async function ttsButtonClick(target) {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${params.oai_key}`
       },
-      body: JSON.stringify(body)
+      body: JSON.stringify(body),
+      signal: controller.signal
     });
 
     if (!audioResp.ok) {
       throw new Error('Audio request failed');
     }
 
-    const blob = await audioResp.blob();
-    const audioUrl = URL.createObjectURL(blob);
+    const mimeType = audioResp.headers.get('Content-Type') || 'audio/mpeg';
+    const mediaSource = new MediaSource();
+    const audioUrl = URL.createObjectURL(mediaSource);
     const audio = new Audio(audioUrl);
     target._audio = audio;
     audio.addEventListener('ended', () => {
@@ -202,16 +219,49 @@ async function ttsButtonClick(target) {
       target.setAttribute('aria-label', 'Lire');
       target.setAttribute('title', 'Lire');
     });
-    audio.play();
-    target.classList.add('oai-playing');
-    target.setAttribute('aria-label', 'Pause');
-    target.setAttribute('title', 'Pause');
-    log.textContent = '';
-    log.style.display = 'none';
+
+    mediaSource.addEventListener('sourceopen', async () => {
+      const sourceBuffer = mediaSource.addSourceBuffer(mimeType);
+      const reader = audioResp.body.getReader();
+      let started = false;
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            sourceBuffer.addEventListener('updateend', () => mediaSource.endOfStream(), { once: true });
+            break;
+          }
+          sourceBuffer.appendBuffer(value);
+          await new Promise(res => sourceBuffer.addEventListener('updateend', res, { once: true }));
+          if (!started) {
+            audio.play();
+            target.classList.add('oai-playing');
+            target.setAttribute('aria-label', 'Pause');
+            target.setAttribute('title', 'Pause');
+            log.textContent = '';
+            log.style.display = 'none';
+            started = true;
+          }
+        }
+      } catch (err) {
+        if (err.name !== 'AbortError') {
+          console.error(err);
+          log.textContent = 'Audio failed';
+          log.style.display = 'block';
+          target.classList.remove('oai-playing');
+          target.setAttribute('aria-label', 'Lire');
+          target.setAttribute('title', 'Lire');
+        }
+      } finally {
+        target._abortController = null;
+      }
+    });
   } catch (err) {
     console.error(err);
-    log.textContent = 'Audio failed';
+    log.textContent = err.name === 'AbortError' ? 'Audio canceled' : 'Audio failed';
     log.style.display = 'block';
+    target._audio = null;
+    target._abortController = null;
   } finally {
     target.disabled = false;
   }


### PR DESCRIPTION
## Summary
- include `stream` flag in TTS parameters from `speakAction`
- stream audio in the browser via `MediaSource` and `SourceBuffer`
- add `AbortController` to cancel fetch and update play/pause UI

## Testing
- `php tests/ArticleSummaryControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa39318a1c83219d6ee4af648b149e