### PR TITLE
Add play button for each article paragraph

### DIFF
--- a/extension.php
+++ b/extension.php
@@ -44,6 +44,10 @@ class ArticleSummaryExtension extends Minz_Extension
     $icon_tts_pause = str_replace('<svg ', '<svg class="oai-tts-icon oai-tts-pause" ', file_get_contents(__DIR__ . '/static/img/pause.svg'));
     $icon = str_replace('<svg ', '<svg class="oai-summary-icon" ', file_get_contents(__DIR__ . '/static/img/summary.svg'));
 
+    $paragraph_button = '<button class="oai-tts-btn oai-tts-paragraph" aria-label="Lire le paragraphe" title="Lire le paragraphe">'
+      . $icon_tts_play . '</button>';
+    $article_content = preg_replace('/<p\b([^>]*)>/', '<p$1>' . $paragraph_button, $entry->content());
+
       $entry->_content(
         '<div class="oai-summary-wrap">'
         . '<button data-request="' . $url_tts . '" class="oai-tts-btn btn btn-small" aria-label="Lire" title="Lire">' . $icon_tts_play . $icon_tts_pause . '</button>'
@@ -55,7 +59,7 @@ class ArticleSummaryExtension extends Minz_Extension
         . '<div class="oai-summary-content"></div>'
         . ($has_more ? '<button data-request="' . $url_more . '" class="oai-summary-btn oai-summary-more btn btn-small" aria-label="Résumé plus long" title="Résumé plus long">+</button>' : '')
         . '</div>'
-        . '<div class="oai-summary-article">' . $entry->content() . '</div>'
+        . '<div class="oai-summary-article">' . $article_content . '</div>'
         . '</div>'
       );
     return $entry;

--- a/static/style.css
+++ b/static/style.css
@@ -106,3 +106,12 @@
   display: none;
   margin-top: 1em;
 }
+
+.oai-summary-article .oai-tts-paragraph {
+  background: none;
+  border: none;
+  padding: 0;
+  margin-right: 0.5em;
+  cursor: pointer;
+}
+


### PR DESCRIPTION
## Summary
- inject a play button before each paragraph in article content
- style paragraph-level play buttons for inline display

## Testing
- `php tests/ArticleSummaryControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68acbefe4d9c832197adb845cf15f461