### PR TITLE
Add adjustable TTS speed

### DIFF
--- a/Controllers/ArticleSummaryController.php
+++ b/Controllers/ArticleSummaryController.php
@@ -110,6 +110,11 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
     $oai_key = FreshRSS_Context::$user_conf->oai_key;
     $tts_model = FreshRSS_Context::$user_conf->oai_tts_model;
     $voice = FreshRSS_Context::$user_conf->oai_voice;
+    $speed = FreshRSS_Context::$user_conf->oai_speed;
+    if ($speed === null || !is_numeric($speed)) {
+      $speed = 1.1;
+    }
+    $speed = max(0.5, min(4, (float)$speed));
     $content = Minz_Request::param('content');
 
     if (
@@ -141,6 +146,7 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
           'oai_key' => $oai_key,
           'model' => $tts_model,
           'voice' => $voice,
+          'speed' => $speed,
           'input' => $content,
           'stream' => true,
           'response_format' => 'opus',
@@ -164,6 +170,11 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
     $oai_key = FreshRSS_Context::$user_conf->oai_key;
     $tts_model = FreshRSS_Context::$user_conf->oai_tts_model;
     $voice = FreshRSS_Context::$user_conf->oai_voice;
+    $speed = FreshRSS_Context::$user_conf->oai_speed;
+    if ($speed === null || !is_numeric($speed)) {
+      $speed = 1.1;
+    }
+    $speed = max(0.5, min(4, (float)$speed));
 
     if (
       $this->isEmpty($oai_url) ||
@@ -193,6 +204,7 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
           'oai_key' => $oai_key,
           'model' => $tts_model,
           'voice' => $voice,
+          'speed' => $speed,
           'response_format' => 'opus',
         ),
         'error' => null

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This project is a fork of [LiangWei88/xExtension-ArticleSummary](https://github.
 - **API Configuration**: Configure the base URL, API key, model name, and prompt through a simple form.
 - **Summarize Button**: Adds a "summarize" button to each article, allowing users to generate a summary with a single click.
 - **Markdown Support**: Converts HTML content to Markdown before sending it to the API.
+- **Text-to-Speech**: Listen to articles using OpenAI's TTS with adjustable reading speed.
 - **Error Handling**: Provides feedback in case of API errors or incomplete configurations.
 - **Smart Fallback**: Uses the article's description if the main content is empty or contains only images.
 
@@ -23,8 +24,10 @@ This project is a fork of [LiangWei88/xExtension-ArticleSummary](https://github.
 1. **Base URL**: Enter the base URL of your language model API (e.g., `https://api.openai.com/`). Do not include the version path (e.g., `/v1`).
 2. **API Key**: Provide your API key for authentication.
 3. **Model Name**: Specify the model name you wish to use for summarization (e.g., `gpt-4.1`).
-4. **Prompt**: Add a prompt that will be included before the article content when sending the request to the API.
-5. **Summary Type**: Choose between "short" and "long" summary outputs.
+4. **Voice & TTS Model**: Choose the voice and TTS model used for audio playback.
+5. **Reading Speed**: Set the playback speed between `0.5` and `4` (default `1.1`).
+6. **Prompt**: Add a prompt that will be included before the article content when sending the request to the API.
+7. **Summary Type**: Choose between "short" and "long" summary outputs.
 
 ## Usage
 

--- a/configure.phtml
+++ b/configure.phtml
@@ -4,6 +4,7 @@ $oai_key = FreshRSS_Context::$user_conf->oai_key;
 $oai_model = FreshRSS_Context::$user_conf->oai_model ?: 'gpt-5-nano';
 $oai_tts_model = FreshRSS_Context::$user_conf->oai_tts_model ?: 'gpt-tts-1';
 $oai_voice = FreshRSS_Context::$user_conf->oai_voice ?: 'alloy';
+$oai_speed = FreshRSS_Context::$user_conf->oai_speed ?: 1.1;
 $oai_prompt = FreshRSS_Context::$user_conf->oai_prompt;
 $oai_prompt_2 = FreshRSS_Context::$user_conf->oai_prompt_2;
 $oai_provider = FreshRSS_Context::$user_conf->oai_provider ?: 'openai'; // Default to OpenAI
@@ -26,6 +27,8 @@ $oai_provider = FreshRSS_Context::$user_conf->oai_provider ?: 'openai'; // Defau
     <input type="text" name="oai_model" id="oai_model" value="<?php echo $oai_model; ?>">
     <label for="oai_voice">Voix</label>
     <input type="text" name="oai_voice" id="oai_voice" value="<?php echo $oai_voice; ?>">
+    <label for="oai_speed">Vitesse de lecture</label>
+    <input type="number" name="oai_speed" id="oai_speed" min="0.5" max="4" step="0.1" value="<?php echo $oai_speed; ?>">
     <label for="oai_tts_model">Modèle TTS</label>
     <input type="text" name="oai_tts_model" id="oai_tts_model" value="<?php echo $oai_tts_model; ?>">
     <label for="oai_prompt">Prompt (add before content)</label>

--- a/extension.php
+++ b/extension.php
@@ -76,6 +76,11 @@ class ArticleSummaryExtension extends Minz_Extension
       FreshRSS_Context::$user_conf->oai_provider = Minz_Request::param('oai_provider', '');
       FreshRSS_Context::$user_conf->oai_tts_model = Minz_Request::param('oai_tts_model', '');
       FreshRSS_Context::$user_conf->oai_voice = Minz_Request::param('oai_voice', '');
+      $speed = (float)Minz_Request::param('oai_speed', 1.1);
+      if ($speed < 0.5 || $speed > 4) {
+        $speed = 1.1;
+      }
+      FreshRSS_Context::$user_conf->oai_speed = $speed;
       FreshRSS_Context::$user_conf->save();
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "ArticleSummary",
   "author": "Liang",
   "description": "A powerful article summarization plugin for FreshRSS that allows users to generate summaries using a language model API conforming to the OpenAI API specification.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "entrypoint": "ArticleSummary",
   "type": "user"
 }

--- a/static/script.js
+++ b/static/script.js
@@ -363,6 +363,7 @@ async function ttsButtonClick(target, forceStop = false, preload = false) {
     const body = {
       model: params.model,
       voice: params.voice,
+      speed: params.speed,
       input: params.input,
       stream: params.stream,
       response_format: params.response_format

--- a/tests/ArticleSummaryControllerTest.php
+++ b/tests/ArticleSummaryControllerTest.php
@@ -35,6 +35,7 @@ FreshRSS_Context::$user_conf = (object) [
     'oai_provider' => 'openai',
     'oai_tts_model' => 'my-tts-model',
     'oai_voice' => 'my-voice',
+    'oai_speed' => 1.1,
 ];
 
 // Capture the output of summarizeAction()
@@ -65,6 +66,7 @@ $ttsOutput = ob_get_clean();
 $ttsData = json_decode($ttsOutput, true);
 $voice = $ttsData['response']['data']['voice'] ?? null;
 $format = $ttsData['response']['data']['response_format'] ?? null;
+$speed = $ttsData['response']['data']['speed'] ?? null;
 
 if ($voice !== 'my-voice') {
     echo "Voice mismatch: expected my-voice, got {$voice}\n";
@@ -76,8 +78,14 @@ if ($format !== 'opus') {
     exit(1);
 }
 
+if ($speed !== 1.1) {
+    echo "Speed mismatch: expected 1.1, got {$speed}\n";
+    exit(1);
+}
+
 echo "Voice matches configuration\n";
 echo "Format matches configuration\n";
+echo "Speed matches configuration\n";
 
 // Test speakAction()
 Minz_Request::$params = ['content' => 'Speak me'];
@@ -87,6 +95,7 @@ $speakOutput = ob_get_clean();
 $speakData = json_decode($speakOutput, true);
 $input = $speakData['response']['data']['input'] ?? null;
 $speakFormat = $speakData['response']['data']['response_format'] ?? null;
+$speakSpeed = $speakData['response']['data']['speed'] ?? null;
 
 if ($input !== 'Speak me') {
     echo "Input mismatch: expected Speak me, got {$input}\n";
@@ -98,5 +107,11 @@ if ($speakFormat !== 'opus') {
     exit(1);
 }
 
+if ($speakSpeed !== 1.1) {
+    echo "Speak speed mismatch: expected 1.1, got {$speakSpeed}\n";
+    exit(1);
+}
+
 echo "Speak action returns input\n";
 echo "Speak action returns format\n";
+echo "Speak action returns speed\n";


### PR DESCRIPTION
## Summary
- allow configuring OpenAI TTS playback speed with default 1.1 and range 0.5–4
- include configured speed in TTS requests and frontend playback
- document new text-to-speech option and bump extension version

## Testing
- `php tests/ArticleSummaryControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad4b15cd3c832189faa841321fe43f