### PR TITLE
Proxy OpenAI/Ollama requests through extension

### DIFF
--- a/Controllers/ArticleSummaryController.php
+++ b/Controllers/ArticleSummaryController.php
@@ -219,7 +219,8 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
   public function proxyAction()
   {
     $this->view->_layout(false);
-    $payload = json_decode(file_get_contents('php://input'), true);
+    $raw = Minz_Request::param('payload');
+    $payload = json_decode($raw, true);
     if (!is_array($payload) || empty($payload['url'])) {
       http_response_code(400);
       return;

--- a/Controllers/ArticleSummaryController.php
+++ b/Controllers/ArticleSummaryController.php
@@ -216,6 +216,58 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
     return;
   }
 
+  public function proxyAction()
+  {
+    $this->view->_layout(false);
+    $payload = json_decode(file_get_contents('php://input'), true);
+    if (!is_array($payload) || empty($payload['url'])) {
+      http_response_code(400);
+      return;
+    }
+
+    $url = $payload['url'];
+    $method = $payload['method'] ?? 'POST';
+    $headers = $payload['headers'] ?? [];
+    $body = isset($payload['body']) ? json_encode($payload['body']) : null;
+
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+    if ($body !== null) {
+      curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+    }
+    if (!empty($headers)) {
+      $curlHeaders = [];
+      foreach ($headers as $k => $v) {
+        $curlHeaders[] = $k . ': ' . $v;
+      }
+      curl_setopt($ch, CURLOPT_HTTPHEADER, $curlHeaders);
+    }
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, false);
+    curl_setopt($ch, CURLOPT_HEADERFUNCTION, function ($ch, $header) {
+      $len = strlen($header);
+      if (stripos($header, 'content-type:') === 0) {
+        header($header);
+      }
+      return $len;
+    });
+    curl_setopt($ch, CURLOPT_WRITEFUNCTION, function ($ch, $chunk) {
+      echo $chunk;
+      if (function_exists('ob_flush')) {
+        @ob_flush();
+      }
+      flush();
+      return strlen($chunk);
+    });
+
+    curl_exec($ch);
+    if (curl_errno($ch)) {
+      http_response_code(500);
+    }
+    curl_close($ch);
+    return;
+  }
+
   private function isEmpty($item)
   {
     return $item === null || trim($item) === '';

--- a/extension.php
+++ b/extension.php
@@ -57,6 +57,10 @@ class ArticleSummaryExtension extends Minz_Extension
       'data-audio-failed' => self::t('audio_failed'),
       'data-receiving-answer' => self::t('receiving_answer'),
       'data-request-failed' => self::t('request_failed'),
+      'data-proxy' => Minz_Url::display(array(
+        'c' => 'ArticleSummary',
+        'a' => 'proxy'
+      )),
     ];
     $attr_str = '';
     foreach ($attrs as $name => $value) {

--- a/extension.php
+++ b/extension.php
@@ -3,10 +3,6 @@ class ArticleSummaryExtension extends Minz_Extension
 {
   private static ?array $i18n = null;
 
-  protected array $csp_policies = [
-    'default-src' => '*',
-  ];
-
   public function init()
   {
     $this->registerHook('entry_before_display', array($this, 'addSummaryButton'));

--- a/static/script.js
+++ b/static/script.js
@@ -388,13 +388,20 @@ async function ttsButtonClick(target, forceStop = false, preload = false) {
     const controller = new AbortController();
     target._abortController = controller;
 
-    const audioResp = await fetch(params.oai_url, {
+    const audioResp = await fetch(container.dataset.proxy, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${params.oai_key}`
+        'Content-Type': 'application/json'
       },
-      body: JSON.stringify(body),
+      body: JSON.stringify({
+        url: params.oai_url,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${params.oai_key}`
+        },
+        body: body
+      }),
       signal: controller.signal
     });
 
@@ -586,13 +593,20 @@ async function sendOpenAIRequest(container, oaiParams) {
     let body = JSON.parse(JSON.stringify(oaiParams));
     delete body['oai_url'];
     delete body['oai_key'];
-    const response = await fetch(oaiParams.oai_url, {
+    const response = await fetch(container.dataset.proxy, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${oaiParams.oai_key}`
+        'Content-Type': 'application/json'
       },
-      body: JSON.stringify(body)
+      body: JSON.stringify({
+        url: oaiParams.oai_url,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${oaiParams.oai_key}`
+        },
+        body: body
+      })
     });
 
     if (!response.ok) {
@@ -663,13 +677,23 @@ async function sendOpenAIRequest(container, oaiParams) {
 async function sendOllamaRequest(container, oaiParams){
   const t = container.dataset;
   try {
-    const response = await fetch(oaiParams.oai_url, {
+    let body = JSON.parse(JSON.stringify(oaiParams));
+    delete body['oai_url'];
+    delete body['oai_key'];
+    const response = await fetch(container.dataset.proxy, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${oaiParams.oai_key}`
+        'Content-Type': 'application/json'
       },
-      body: JSON.stringify(oaiParams)
+      body: JSON.stringify({
+        url: oaiParams.oai_url,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${oaiParams.oai_key}`
+        },
+        body: body
+      })
     });
 
     if (!response.ok) {

--- a/static/script.js
+++ b/static/script.js
@@ -127,6 +127,12 @@ async function summarizeButtonClick(target) {
   }
 }
 
+function getProxyUrl(container) {
+  const base = container.dataset.proxy;
+  const sep = base.includes('?') ? '&' : '?';
+  return base + sep + 'ajax=true&_csrf=' + encodeURIComponent(context.csrf);
+}
+
 async function ttsButtonClick(target, forceStop = false, preload = false) {
   const container = target.closest('.oai-summary-wrap');
   const log = container.querySelector('.oai-summary-log');
@@ -388,7 +394,8 @@ async function ttsButtonClick(target, forceStop = false, preload = false) {
     const controller = new AbortController();
     target._abortController = controller;
 
-    const audioResp = await fetch(container.dataset.proxy, {
+    const proxyUrl = getProxyUrl(container);
+    const audioResp = await fetch(proxyUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
@@ -593,7 +600,8 @@ async function sendOpenAIRequest(container, oaiParams) {
     let body = JSON.parse(JSON.stringify(oaiParams));
     delete body['oai_url'];
     delete body['oai_key'];
-    const response = await fetch(container.dataset.proxy, {
+    const proxyUrl = getProxyUrl(container);
+    const response = await fetch(proxyUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
@@ -680,7 +688,8 @@ async function sendOllamaRequest(container, oaiParams){
     let body = JSON.parse(JSON.stringify(oaiParams));
     delete body['oai_url'];
     delete body['oai_key'];
-    const response = await fetch(container.dataset.proxy, {
+    const proxyUrl = getProxyUrl(container);
+    const response = await fetch(proxyUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'

--- a/static/script.js
+++ b/static/script.js
@@ -128,9 +128,7 @@ async function summarizeButtonClick(target) {
 }
 
 function getProxyUrl(container) {
-  const base = container.dataset.proxy;
-  const sep = base.includes('?') ? '&' : '?';
-  return base + sep + 'ajax=true&_csrf=' + encodeURIComponent(context.csrf);
+  return container.dataset.proxy;
 }
 
 async function ttsButtonClick(target, forceStop = false, preload = false) {
@@ -395,20 +393,24 @@ async function ttsButtonClick(target, forceStop = false, preload = false) {
     target._abortController = controller;
 
     const proxyUrl = getProxyUrl(container);
+    const proxyParams = new URLSearchParams();
+    proxyParams.append('ajax', 'true');
+    proxyParams.append('_csrf', context.csrf);
+    proxyParams.append('payload', JSON.stringify({
+      url: params.oai_url,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${params.oai_key}`
+      },
+      body: body
+    }));
     const audioResp = await fetch(proxyUrl, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/x-www-form-urlencoded'
       },
-      body: JSON.stringify({
-        url: params.oai_url,
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${params.oai_key}`
-        },
-        body: body
-      }),
+      body: proxyParams,
       signal: controller.signal
     });
 
@@ -601,20 +603,24 @@ async function sendOpenAIRequest(container, oaiParams) {
     delete body['oai_url'];
     delete body['oai_key'];
     const proxyUrl = getProxyUrl(container);
+    const proxyParams = new URLSearchParams();
+    proxyParams.append('ajax', 'true');
+    proxyParams.append('_csrf', context.csrf);
+    proxyParams.append('payload', JSON.stringify({
+      url: oaiParams.oai_url,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${oaiParams.oai_key}`
+      },
+      body: body
+    }));
     const response = await fetch(proxyUrl, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/x-www-form-urlencoded'
       },
-      body: JSON.stringify({
-        url: oaiParams.oai_url,
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${oaiParams.oai_key}`
-        },
-        body: body
-      })
+      body: proxyParams
     });
 
     if (!response.ok) {
@@ -689,20 +695,24 @@ async function sendOllamaRequest(container, oaiParams){
     delete body['oai_url'];
     delete body['oai_key'];
     const proxyUrl = getProxyUrl(container);
+    const proxyParams = new URLSearchParams();
+    proxyParams.append('ajax', 'true');
+    proxyParams.append('_csrf', context.csrf);
+    proxyParams.append('payload', JSON.stringify({
+      url: oaiParams.oai_url,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${oaiParams.oai_key}`
+      },
+      body: body
+    }));
     const response = await fetch(proxyUrl, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/x-www-form-urlencoded'
       },
-      body: JSON.stringify({
-        url: oaiParams.oai_url,
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${oaiParams.oai_key}`
-        },
-        body: body
-      })
+      body: proxyParams
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- add `proxyAction` controller to forward OpenAI and Ollama calls and stream responses
- expose proxy URL in article markup so JS can route requests through extension
- update client code to send all AI and TTS requests via the proxy, preserving streaming

## Testing
- `php tests/ArticleSummaryControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2e7fe52d48321afaea3bf41ca0589