### PR TITLE
Rename extension to SummaryAndAudio

### DIFF
--- a/Controllers/SummaryAndAudioController.php
+++ b/Controllers/SummaryAndAudioController.php
@@ -1,6 +1,6 @@
 <?php
 
-class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
+class FreshExtension_SummaryAndAudio_Controller extends Minz_ActionController
 {
   public function summarizeAction()
   {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FreshRSS Article Summary Extension
 
-This project is a fork of [LiangWei88/xExtension-ArticleSummary](https://github.com/LiangWei88/xExtension-ArticleSummary), updated to better integrate with FreshRSS and to leverage the latest OpenAI API models. In addition to the original summarization capabilities, this version allows users to generate two types of summaries: a concise short summary and a more detailed long summary.
+SummaryAndAudio is a fork of [LiangWei88/xExtension-ArticleSummary](https://github.com/LiangWei88/xExtension-ArticleSummary), updated to better integrate with FreshRSS and to leverage the latest OpenAI API models. In addition to the original summarization capabilities, this version allows users to generate two types of summaries: a concise short summary and a more detailed long summary.
 
 ## Features
 - **Forked and Modernized**: Originates from the LiangWei88 project but refactored for smoother integration and maintenance within FreshRSS.
@@ -16,7 +16,7 @@ This project is a fork of [LiangWei88/xExtension-ArticleSummary](https://github.
 ## Installation
 
 1. **Download the Extension**: Clone or download this repository to your FreshRSS extensions directory.
-2. **Enable the Extension**: Go to the FreshRSS extensions management page and enable the "ArticleSummary" extension.
+2. **Enable the Extension**: Go to the FreshRSS extensions management page and enable the "SummaryAndAudio" extension.
 3. **Configure the Extension**: Navigate to the extension's configuration page to set up your API details.
 
 ## Configuration

--- a/configure.phtml
+++ b/configure.phtml
@@ -14,35 +14,35 @@ $oai_provider = FreshRSS_Context::$user_conf->oai_provider ?: 'openai'; // Defau
   <input type="hidden" name="_csrf" value="<?php echo FreshRSS_Auth::csrfToken(); ?>" />
 
   <fieldset>
-    <legend><?php echo ArticleSummaryExtension::t('summary_settings'); ?></legend>
-    <label for="oai_provider"><?php echo ArticleSummaryExtension::t('choose_provider'); ?></label>
+    <legend><?php echo SummaryAndAudioExtension::t('summary_settings'); ?></legend>
+    <label for="oai_provider"><?php echo SummaryAndAudioExtension::t('choose_provider'); ?></label>
     <select name="oai_provider">
-      <option value="openai" <?php echo ($oai_provider == 'openai' ? 'selected' : ''); ?>><?php echo ArticleSummaryExtension::t('openai'); ?></option>
-      <option value="ollama" <?php echo ($oai_provider == 'ollama' ? 'selected' : ''); ?>><?php echo ArticleSummaryExtension::t('ollama'); ?></option>
+      <option value="openai" <?php echo ($oai_provider == 'openai' ? 'selected' : ''); ?>><?php echo SummaryAndAudioExtension::t('openai'); ?></option>
+      <option value="ollama" <?php echo ($oai_provider == 'ollama' ? 'selected' : ''); ?>><?php echo SummaryAndAudioExtension::t('ollama'); ?></option>
     </select>
-    <label for="oai_url"><?php echo ArticleSummaryExtension::t('base_url'); ?></label>
+    <label for="oai_url"><?php echo SummaryAndAudioExtension::t('base_url'); ?></label>
     <input type="text" name="oai_url" id="oai_url" value="<?php echo $oai_url; ?>">
-    <label for="oai_key"><?php echo ArticleSummaryExtension::t('api_key'); ?></label>
+    <label for="oai_key"><?php echo SummaryAndAudioExtension::t('api_key'); ?></label>
     <input type="text" name="oai_key" id="oai_key" value="<?php echo $oai_key; ?>">
-    <label for="oai_model"><?php echo ArticleSummaryExtension::t('model_name'); ?></label>
+    <label for="oai_model"><?php echo SummaryAndAudioExtension::t('model_name'); ?></label>
     <input type="text" name="oai_model" id="oai_model" value="<?php echo $oai_model; ?>">
-    <label for="oai_prompt"><?php echo ArticleSummaryExtension::t('prompt'); ?></label>
+    <label for="oai_prompt"><?php echo SummaryAndAudioExtension::t('prompt'); ?></label>
     <textarea name="oai_prompt" id="oai_prompt"><?php echo $oai_prompt; ?></textarea>
-    <label for="oai_prompt_2"><?php echo ArticleSummaryExtension::t('prompt_2'); ?></label>
+    <label for="oai_prompt_2"><?php echo SummaryAndAudioExtension::t('prompt_2'); ?></label>
     <textarea name="oai_prompt_2" id="oai_prompt_2"><?php echo $oai_prompt_2; ?></textarea>
   </fieldset>
 
   <fieldset>
-    <legend><?php echo ArticleSummaryExtension::t('audio_settings'); ?></legend>
-    <p><?php echo ArticleSummaryExtension::t('audio_openai_only'); ?></p>
-    <label for="oai_voice"><?php echo ArticleSummaryExtension::t('voice'); ?></label>
+    <legend><?php echo SummaryAndAudioExtension::t('audio_settings'); ?></legend>
+    <p><?php echo SummaryAndAudioExtension::t('audio_openai_only'); ?></p>
+    <label for="oai_voice"><?php echo SummaryAndAudioExtension::t('voice'); ?></label>
     <input type="text" name="oai_voice" id="oai_voice" value="<?php echo $oai_voice; ?>">
-    <label for="oai_speed"><?php echo ArticleSummaryExtension::t('speech_speed'); ?></label>
+    <label for="oai_speed"><?php echo SummaryAndAudioExtension::t('speech_speed'); ?></label>
     <input type="number" name="oai_speed" id="oai_speed" min="0.5" max="4" step="0.1" value="<?php echo $oai_speed; ?>">
-    <label for="oai_tts_model"><?php echo ArticleSummaryExtension::t('tts_model'); ?></label>
+    <label for="oai_tts_model"><?php echo SummaryAndAudioExtension::t('tts_model'); ?></label>
     <input type="text" name="oai_tts_model" id="oai_tts_model" value="<?php echo $oai_tts_model; ?>">
   </fieldset>
 
   <hr />
-  <button type="submit"><?php echo ArticleSummaryExtension::t('save'); ?></button>
+  <button type="submit"><?php echo SummaryAndAudioExtension::t('save'); ?></button>
 </form>

--- a/extension.php
+++ b/extension.php
@@ -1,5 +1,5 @@
 <?php
-class ArticleSummaryExtension extends Minz_Extension
+class SummaryAndAudioExtension extends Minz_Extension
 {
   private static ?array $i18n = null;
 
@@ -10,7 +10,7 @@ class ArticleSummaryExtension extends Minz_Extension
   public function init()
   {
     $this->registerHook('entry_before_display', array($this, 'addSummaryButton'));
-    $this->registerController('ArticleSummary');
+    $this->registerController('SummaryAndAudio');
     Minz_View::appendStyle($this->getFileUrl('style.css', 'css'));
     Minz_View::appendScript($this->getFileUrl('axios.js', 'js'));
     Minz_View::appendScript($this->getFileUrl('marked.js', 'js'));
@@ -20,14 +20,14 @@ class ArticleSummaryExtension extends Minz_Extension
   public function addSummaryButton($entry)
   {
     $url_summary = Minz_Url::display(array(
-      'c' => 'ArticleSummary',
+      'c' => 'SummaryAndAudio',
       'a' => 'summarize',
       'params' => array(
         'id' => $entry->id()
       )
     ));
     $url_more = Minz_Url::display(array(
-      'c' => 'ArticleSummary',
+      'c' => 'SummaryAndAudio',
       'a' => 'summarize',
       'params' => array(
         'id' => $entry->id(),
@@ -37,7 +37,7 @@ class ArticleSummaryExtension extends Minz_Extension
     $has_more = trim((string)FreshRSS_Context::$user_conf->oai_prompt_2) !== '';
 
     $url_tts = Minz_Url::display(array(
-      'c' => 'ArticleSummary',
+      'c' => 'SummaryAndAudio',
       'a' => 'speak'
     ));
     $icon_tts_play = str_replace('<svg ', '<svg class="oai-tts-icon oai-tts-play" ', file_get_contents(__DIR__ . '/static/img/play.svg'));

--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
   "author": "win-100",
   "description": "FreshRSS extension that generates concise and detailed summaries using the OpenAI API and lets you listen to articles through customizable text-to-speech. Easily configure the model, API key, and reading speed to get the most out of your RSS feeds.",
   "version": "0.1.4",
-  "entrypoint": "ArticleSummary",
+  "entrypoint": "SummaryAndAudio",
   "type": "user"
 }

--- a/tests/SummaryAndAudioControllerTest.php
+++ b/tests/SummaryAndAudioControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 error_reporting(E_ERROR);
-require __DIR__ . '/../Controllers/ArticleSummaryController.php';
+require __DIR__ . '/../Controllers/SummaryAndAudioController.php';
 
 // Stub classes and functions required by the controller
 class Minz_ActionController {}
@@ -40,7 +40,7 @@ FreshRSS_Context::$user_conf = (object) [
 
 // Capture the output of summarizeAction()
 ob_start();
-$controller = new FreshExtension_ArticleSummary_Controller();
+$controller = new FreshExtension_SummaryAndAudio_Controller();
 $controller->view = new class {
     public function _layout($layout) {}
 };


### PR DESCRIPTION
## Summary
- rename extension classes and controller to `SummaryAndAudio`
- update configuration templates, metadata, and README for the new name

## Testing
- `php tests/SummaryAndAudioControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2fd4d64448321b514009cc1657710