### PR TITLE
Proxy audio generation through server

### DIFF
--- a/Controllers/SummaryAndAudioController.php
+++ b/Controllers/SummaryAndAudioController.php
@@ -104,7 +104,6 @@ class FreshExtension_SummaryAndAudio_Controller extends Minz_ActionController
   public function speakAction()
   {
     $this->view->_layout(false);
-    header('Content-Type: application/json');
 
     $oai_url = FreshRSS_Context::$user_conf->oai_url;
     $oai_key = FreshRSS_Context::$user_conf->oai_key;
@@ -116,6 +115,8 @@ class FreshExtension_SummaryAndAudio_Controller extends Minz_ActionController
     }
     $speed = max(0.5, min(4, (float)$speed));
     $content = Minz_Request::param('content');
+    $format = Minz_Request::param('format');
+    $format = in_array($format, ['mp3', 'ogg', 'opus']) ? $format : 'opus';
 
     if (
       $this->isEmpty($oai_url) ||
@@ -124,6 +125,7 @@ class FreshExtension_SummaryAndAudio_Controller extends Minz_ActionController
       $this->isEmpty($voice) ||
       $this->isEmpty($content)
     ) {
+      header('Content-Type: application/json');
       echo json_encode(array(
         'response' => array(
           'data' => 'missing config',
@@ -138,26 +140,82 @@ class FreshExtension_SummaryAndAudio_Controller extends Minz_ActionController
     if (!preg_match('/\/v\d+\/?$/', $oai_url)) {
       $oai_url .= '/v1';
     }
+    $tts_url = $oai_url . '/audio/speech';
 
-    $successResponse = array(
-      'response' => array(
-        'data' => array(
-          'oai_url' => $oai_url . '/audio/speech',
-          'oai_key' => $oai_key,
-          'model' => $tts_model,
-          'voice' => $voice,
-          'speed' => $speed,
-          'input' => $content,
-          'stream' => true,
-          'response_format' => 'opus',
+    $headersSent = false;
+    $statusCode = 0;
+    $respContentType = '';
+    $errorBody = '';
+
+    $ch = curl_init($tts_url);
+    $payload = json_encode([
+      'model' => $tts_model,
+      'voice' => $voice,
+      'speed' => $speed,
+      'input' => $content,
+      'stream' => true,
+      'response_format' => $format,
+    ]);
+    curl_setopt_array($ch, [
+      CURLOPT_POST => true,
+      CURLOPT_HTTPHEADER => [
+        'Content-Type: application/json',
+        'Authorization: Bearer ' . $oai_key,
+      ],
+      CURLOPT_POSTFIELDS => $payload,
+      CURLOPT_HEADERFUNCTION => function ($curl, $header) use (&$statusCode, &$respContentType) {
+        $len = strlen($header);
+        if (preg_match('#HTTP/\d+\.\d+\s+(\d+)#', $header, $m)) {
+          $statusCode = (int)$m[1];
+        } elseif (stripos($header, 'Content-Type:') === 0) {
+          $respContentType = trim(substr($header, 13));
+        }
+        return $len;
+      },
+      CURLOPT_WRITEFUNCTION => function ($curl, $data) use (&$headersSent, &$statusCode, &$respContentType, &$errorBody) {
+        if (!$headersSent) {
+          if ($statusCode >= 200 && $statusCode < 300) {
+            $type = $respContentType ?: 'audio/ogg';
+            header('Content-Type: ' . $type);
+            header('Cache-Control: no-cache');
+          } else {
+            header('Content-Type: application/json', true, $statusCode ?: 500);
+          }
+          $headersSent = true;
+        }
+        if ($statusCode >= 200 && $statusCode < 300) {
+          echo $data;
+          if (function_exists('ob_flush')) {
+            @ob_flush();
+          }
+          flush();
+        } else {
+          $errorBody .= $data;
+        }
+        return strlen($data);
+      },
+    ]);
+
+    curl_exec($ch);
+    curl_close($ch);
+
+    if ($statusCode < 200 || $statusCode >= 300) {
+      if (!$headersSent) {
+        header('Content-Type: application/json', true, $statusCode ?: 500);
+      }
+      $msg = 'Audio request failed';
+      $decoded = json_decode($errorBody, true);
+      if ($decoded && isset($decoded['error']['message'])) {
+        $msg = $decoded['error']['message'];
+      }
+      echo json_encode(array(
+        'response' => array(
+          'data' => '',
+          'error' => $msg,
         ),
-        'provider' => 'openai',
-        'error' => null
-      ),
-      'status' => 200
-    );
-
-    echo json_encode($successResponse);
+        'status' => $statusCode ?: 500,
+      ));
+    }
     return;
   }
 

--- a/Controllers/SummaryAndAudioController.php
+++ b/Controllers/SummaryAndAudioController.php
@@ -164,7 +164,7 @@ class FreshExtension_SummaryAndAudio_Controller extends Minz_ActionController
       CURLOPT_POSTFIELDS => $payload,
       CURLOPT_HEADERFUNCTION => function ($curl, $header) use (&$statusCode, &$respContentType) {
         $len = strlen($header);
-        if (preg_match('#HTTP/\d+\.\d+\s+(\d+)#', $header, $m)) {
+        if (preg_match('#HTTP/\d+(?:\.\d+)?\s+(\d+)#', $header, $m)) {
           $statusCode = (int)$m[1];
         } elseif (stripos($header, 'Content-Type:') === 0) {
           $respContentType = trim(substr($header, 13));

--- a/Controllers/SummaryAndAudioController.php
+++ b/Controllers/SummaryAndAudioController.php
@@ -153,8 +153,7 @@ class FreshExtension_SummaryAndAudio_Controller extends Minz_ActionController
       'voice' => $voice,
       'speed' => $speed,
       'input' => $content,
-      'stream' => true,
-      'response_format' => $format,
+      'format' => $format,
     ]);
     curl_setopt_array($ch, [
       CURLOPT_POST => true,
@@ -196,10 +195,13 @@ class FreshExtension_SummaryAndAudio_Controller extends Minz_ActionController
       },
     ]);
 
-    curl_exec($ch);
+    $result = curl_exec($ch);
+    if ($result === false && !$headersSent) {
+      $errorBody = curl_error($ch);
+    }
     curl_close($ch);
 
-    if ($statusCode < 200 || $statusCode >= 300) {
+    if ($result === false || $statusCode < 200 || $statusCode >= 300) {
       if (!$headersSent) {
         header('Content-Type: application/json', true, $statusCode ?: 500);
       }
@@ -263,7 +265,7 @@ class FreshExtension_SummaryAndAudio_Controller extends Minz_ActionController
           'model' => $tts_model,
           'voice' => $voice,
           'speed' => $speed,
-          'response_format' => 'opus',
+          'format' => 'opus',
         ),
         'error' => null
       ),

--- a/static/script.js
+++ b/static/script.js
@@ -343,10 +343,21 @@ async function ttsButtonClick(target, forceStop = false, preload = false) {
   }
 
   const url = target.dataset.request;
-  const data = new URLSearchParams();
-  data.append('ajax', 'true');
-  data.append('_csrf', context.csrf);
-  data.append('content', text);
+  const form = new URLSearchParams();
+  form.append('ajax', 'true');
+  form.append('_csrf', context.csrf);
+  form.append('content', text);
+
+  let responseFormat = 'opus';
+  if (!('MediaSource' in window) || !MediaSource.isTypeSupported('audio/ogg; codecs=opus')) {
+    const testAudio = document.createElement('audio');
+    if (testAudio.canPlayType('audio/mpeg')) {
+      responseFormat = 'mp3';
+    } else if (testAudio.canPlayType('audio/ogg; codecs=opus')) {
+      responseFormat = 'ogg';
+    }
+  }
+  form.append('format', responseFormat);
 
   if (!preload) {
     target.disabled = true;
@@ -355,51 +366,20 @@ async function ttsButtonClick(target, forceStop = false, preload = false) {
   }
 
   try {
-    const response = await axios.post(url, data, {
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded'
-      }
-    });
-
-    const xresp = response.data;
-    if (response.status !== 200 || !xresp.response || !xresp.response.data || xresp.response.error) {
-      throw new Error(msgRequestFailed);
-    }
-
-    const params = xresp.response.data;
-    const body = {
-      model: params.model,
-      voice: params.voice,
-      speed: params.speed,
-      input: params.input,
-      stream: params.stream,
-      response_format: params.response_format
-    };
-
-    if (!('MediaSource' in window) || !MediaSource.isTypeSupported('audio/ogg; codecs=opus')) {
-      const testAudio = document.createElement('audio');
-      if (testAudio.canPlayType('audio/mpeg')) {
-        body.response_format = 'mp3';
-      } else if (testAudio.canPlayType('audio/ogg; codecs=opus')) {
-        body.response_format = 'ogg';
-      }
-    }
-
     const controller = new AbortController();
     target._abortController = controller;
 
-    const audioResp = await fetch(params.oai_url, {
+    const audioResp = await fetch(url, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${params.oai_key}`
+        'Content-Type': 'application/x-www-form-urlencoded'
       },
-      body: JSON.stringify(body),
+      body: form.toString(),
       signal: controller.signal
     });
 
     if (!audioResp.ok) {
-      throw new Error('Audio request failed');
+      throw new Error(msgRequestFailed);
     }
 
     const mimeType = audioResp.headers.get('Content-Type') || 'audio/ogg';

--- a/static/script.js
+++ b/static/script.js
@@ -142,7 +142,7 @@ async function ttsButtonClick(target, forceStop = false, preload = false) {
     if (!parent || !parent._sequence) return;
     const seq = parent._sequence;
     const nextBtn = seq.buttons[seq.index];
-    if (nextBtn && !nextBtn._audio && !nextBtn._abortController) {
+    if (nextBtn && !nextBtn._audio) {
       ttsButtonClick(nextBtn, false, true);
     }
   };
@@ -238,12 +238,8 @@ async function ttsButtonClick(target, forceStop = false, preload = false) {
       return;
     }
     if (forceStop) {
-      if (target._abortController) {
-        target._abortController.abort();
-        target._abortController = null;
-        URL.revokeObjectURL(target._audio.src);
-      }
       target._audio.pause();
+      target._audio.src = '';
       target._audio = null;
       log.textContent = '';
       log.style.display = 'none';
@@ -297,17 +293,7 @@ async function ttsButtonClick(target, forceStop = false, preload = false) {
         return;
       }
     } else {
-      if (target._abortController) {
-        target._abortController.abort();
-        target._abortController = null;
-        URL.revokeObjectURL(target._audio.src);
-        target._audio.pause();
-        target._audio = null;
-        log.textContent = '';
-        log.style.display = 'none';
-      } else {
-        target._audio.pause();
-      }
+      target._audio.pause();
       target.classList.remove('oai-playing');
       target.setAttribute('aria-label', readLabel);
       target.setAttribute('title', readLabel);
@@ -348,12 +334,12 @@ async function ttsButtonClick(target, forceStop = false, preload = false) {
   form.append('_csrf', context.csrf);
   form.append('content', text);
 
+  const testAudio = document.createElement('audio');
   let responseFormat = 'opus';
-  if (!('MediaSource' in window) || !MediaSource.isTypeSupported('audio/ogg; codecs=opus')) {
-    const testAudio = document.createElement('audio');
+  if (!testAudio.canPlayType('audio/ogg; codecs=opus')) {
     if (testAudio.canPlayType('audio/mpeg')) {
       responseFormat = 'mp3';
-    } else if (testAudio.canPlayType('audio/ogg; codecs=opus')) {
+    } else if (testAudio.canPlayType('audio/ogg')) {
       responseFormat = 'ogg';
     }
   }
@@ -364,38 +350,29 @@ async function ttsButtonClick(target, forceStop = false, preload = false) {
     log.textContent = msgPrepAudio;
     log.style.display = 'block';
   }
-
   try {
-    const controller = new AbortController();
-    target._abortController = controller;
-
-    const audioResp = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded'
-      },
-      body: form.toString(),
-      signal: controller.signal
-    });
-
-    if (!audioResp.ok) {
-      throw new Error(msgRequestFailed);
-    }
-
-    const mimeType = audioResp.headers.get('Content-Type') || 'audio/ogg';
-    let sourceType = mimeType.includes('ogg') ? 'audio/ogg; codecs=opus' : mimeType;
-    if (mimeType === 'audio/opus') {
-      sourceType = 'audio/ogg; codecs=opus';
-    }
-
-    const testAudio = document.createElement('audio');
-    const mseSupported = typeof MediaSource !== 'undefined' && MediaSource.isTypeSupported(sourceType);
-    if (!mseSupported) {
-      if (testAudio.canPlayType(sourceType)) {
-        const blobUrl = URL.createObjectURL(await audioResp.blob());
-        const audio = new Audio(blobUrl);
-        target._audio = audio;
-        audio.addEventListener('ended', () => {
+    const audio = target._audio || document.createElement('audio');
+    if (!target._audio) {
+      const qs = url.includes('?') ? '&' : '?';
+      const audioUrl = url + qs + form.toString();
+      audio.src = audioUrl;
+      audio.preload = 'auto';
+      audio.load();
+      audio.addEventListener('ended', () => {
+        target.classList.remove('oai-playing');
+        target.setAttribute('aria-label', readLabel);
+        target.setAttribute('title', readLabel);
+        if (target._sequenceParent) {
+          const parent = target._sequenceParent;
+          target._sequenceParent = null;
+          parent._playNextParagraph();
+        }
+      });
+      audio.addEventListener(
+        'error',
+        () => {
+          log.textContent = msgAudioFailed;
+          log.style.display = 'block';
           target.classList.remove('oai-playing');
           target.setAttribute('aria-label', readLabel);
           target.setAttribute('title', readLabel);
@@ -404,155 +381,37 @@ async function ttsButtonClick(target, forceStop = false, preload = false) {
             target._sequenceParent = null;
             parent._playNextParagraph();
           }
-        });
-        if (!preload) {
-          target.classList.add('oai-playing');
-          target.setAttribute('aria-label', pauseLabel);
-          target.setAttribute('title', pauseLabel);
-          log.textContent = '';
-          log.style.display = 'none';
-        }
-        target._abortController = null;
-        if (!preload) {
-          try {
-            await audio.play();
-            maybePreloadNext(target);
-          } catch (err) {
-            console.error('Playback failed', err);
-            log.textContent = msgAudioFailed;
-            log.style.display = 'block';
-            target.classList.remove('oai-playing');
-            target.setAttribute('aria-label', readLabel);
-            target.setAttribute('title', readLabel);
-            if (target._sequenceParent) {
-              const parent = target._sequenceParent;
-              target._sequenceParent = null;
-              parent._playNextParagraph();
-            }
-            audio.addEventListener(
-              'canplay',
-              async () => {
-                try {
-                  await audio.play();
-                  target.classList.add('oai-playing');
-                  target.setAttribute('aria-label', pauseLabel);
-                  target.setAttribute('title', pauseLabel);
-                  log.textContent = '';
-                  log.style.display = 'none';
-                  maybePreloadNext(target);
-                } catch (err2) {
-                  console.error('Playback retry failed', err2);
-                }
-              },
-              { once: true }
-            );
-          }
-        }
-        return;
-      }
-      throw new Error('Unsupported audio format');
+        },
+        { once: true }
+      );
     }
-    const mediaSource = new MediaSource();
-    const audioUrl = URL.createObjectURL(mediaSource);
-    const audio = new Audio(audioUrl);
     target._audio = audio;
-    audio.addEventListener('ended', () => {
-      target.classList.remove('oai-playing');
-      target.setAttribute('aria-label', readLabel);
-      target.setAttribute('title', readLabel);
-      if (target._sequenceParent) {
-        const parent = target._sequenceParent;
-        target._sequenceParent = null;
-        parent._playNextParagraph();
-      }
-    });
 
-    mediaSource.addEventListener('sourceopen', async () => {
-      const sourceBuffer = mediaSource.addSourceBuffer(sourceType);
-      const reader = audioResp.body.getReader();
-      let started = false;
+    if (!preload) {
       try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) {
-            sourceBuffer.addEventListener('updateend', () => mediaSource.endOfStream(), { once: true });
-            break;
-          }
-          sourceBuffer.appendBuffer(value);
-          await new Promise(res => sourceBuffer.addEventListener('updateend', res, { once: true }));
-          if (!started && !preload) {
-            try {
-              await audio.play();
-              target.classList.add('oai-playing');
-              target.setAttribute('aria-label', pauseLabel);
-              target.setAttribute('title', pauseLabel);
-              log.textContent = '';
-              log.style.display = 'none';
-              maybePreloadNext(target);
-              started = true;
-            } catch (err) {
-              console.error('Playback failed', err);
-              log.textContent = msgAudioFailed;
-              log.style.display = 'block';
-              target.classList.remove('oai-playing');
-              target.setAttribute('aria-label', readLabel);
-              target.setAttribute('title', readLabel);
-              if (target._sequenceParent) {
-                const parent = target._sequenceParent;
-                target._sequenceParent = null;
-                parent._playNextParagraph();
-              }
-              audio.addEventListener(
-                'canplay',
-                async () => {
-                  try {
-                    await audio.play();
-                    target.classList.add('oai-playing');
-                    target.setAttribute('aria-label', pauseLabel);
-                    target.setAttribute('title', pauseLabel);
-                    log.textContent = '';
-                    log.style.display = 'none';
-                    maybePreloadNext(target);
-                  } catch (err2) {
-                    console.error('Playback retry failed', err2);
-                  }
-                },
-                { once: true }
-              );
-            }
-          }
-        }
+        await audio.play();
+        target.classList.add('oai-playing');
+        target.setAttribute('aria-label', pauseLabel);
+        target.setAttribute('title', pauseLabel);
+        log.textContent = '';
+        log.style.display = 'none';
+        maybePreloadNext(target);
       } catch (err) {
-        if (err.name !== 'AbortError') {
-          console.error(err);
-          if (!preload) {
-            log.textContent = 'Audio failed';
-            log.style.display = 'block';
-            target.classList.remove('oai-playing');
-            target.setAttribute('aria-label', readLabel);
-            target.setAttribute('title', readLabel);
-          }
-        }
-      } finally {
-        target._abortController = null;
+        console.error('Playback failed', err);
+        log.textContent = msgAudioFailed;
+        log.style.display = 'block';
+        target.classList.remove('oai-playing');
+        target.setAttribute('aria-label', readLabel);
+        target.setAttribute('title', readLabel);
       }
-    });
+    }
   } catch (err) {
     console.error(err);
     if (!preload) {
-      log.textContent = err.name === 'AbortError' ? 'Audio canceled' : 'Audio failed';
+      log.textContent = msgAudioFailed;
       log.style.display = 'block';
-      target._audio = null;
-      target._abortController = null;
-      if (target._sequenceParent) {
-        const parent = target._sequenceParent;
-        target._sequenceParent = null;
-        parent._playNextParagraph();
-      }
-    } else {
-      target._audio = null;
-      target._abortController = null;
     }
+    target._audio = null;
   } finally {
     if (!preload) {
       target.disabled = false;

--- a/tests/SummaryAndAudioControllerTest.php
+++ b/tests/SummaryAndAudioControllerTest.php
@@ -87,31 +87,3 @@ echo "Voice matches configuration\n";
 echo "Format matches configuration\n";
 echo "Speed matches configuration\n";
 
-// Test speakAction()
-Minz_Request::$params = ['content' => 'Speak me'];
-ob_start();
-$controller->speakAction();
-$speakOutput = ob_get_clean();
-$speakData = json_decode($speakOutput, true);
-$input = $speakData['response']['data']['input'] ?? null;
-$speakFormat = $speakData['response']['data']['response_format'] ?? null;
-$speakSpeed = $speakData['response']['data']['speed'] ?? null;
-
-if ($input !== 'Speak me') {
-    echo "Input mismatch: expected Speak me, got {$input}\n";
-    exit(1);
-}
-
-if ($speakFormat !== 'opus') {
-    echo "Speak format mismatch: expected opus, got {$speakFormat}\n";
-    exit(1);
-}
-
-if ($speakSpeed !== 1.1) {
-    echo "Speak speed mismatch: expected 1.1, got {$speakSpeed}\n";
-    exit(1);
-}
-
-echo "Speak action returns input\n";
-echo "Speak action returns format\n";
-echo "Speak action returns speed\n";

--- a/tests/SummaryAndAudioControllerTest.php
+++ b/tests/SummaryAndAudioControllerTest.php
@@ -87,3 +87,23 @@ echo "Voice matches configuration\n";
 echo "Format matches configuration\n";
 echo "Speed matches configuration\n";
 
+// Verify header status code regex supports HTTP/2 responses
+$pattern = '#HTTP/\d+(?:\.\d+)?\s+(\d+)#';
+$headers = [
+    'HTTP/2 200',
+    'HTTP/1.1 404',
+];
+foreach ($headers as $line) {
+    if (!preg_match($pattern, $line, $m)) {
+        echo "Regex failed to match header: {$line}\n";
+        exit(1);
+    }
+    // Ensure captured status is numeric
+    if (!is_numeric($m[1])) {
+        echo "Regex did not capture status code for header: {$line}\n";
+        exit(1);
+    }
+}
+
+echo "Header regex matches HTTP/2 and HTTP/1.x responses\n";
+

--- a/tests/SummaryAndAudioControllerTest.php
+++ b/tests/SummaryAndAudioControllerTest.php
@@ -65,7 +65,7 @@ $controller->fetchTtsParamsAction();
 $ttsOutput = ob_get_clean();
 $ttsData = json_decode($ttsOutput, true);
 $voice = $ttsData['response']['data']['voice'] ?? null;
-$format = $ttsData['response']['data']['response_format'] ?? null;
+$format = $ttsData['response']['data']['format'] ?? null;
 $speed = $ttsData['response']['data']['speed'] ?? null;
 
 if ($voice !== 'my-voice') {


### PR DESCRIPTION
## Summary
- Stream OpenAI text-to-speech responses through the server so API keys stay server-side.
- Adjust front-end to request audio directly from the server and handle streamed audio responses.
- Simplify unit tests to align with the new server-based audio workflow.

## Testing
- `php tests/SummaryAndAudioControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c3d5756554832195dc3201dd66137e