### PR TITLE
Proxy summary requests through server

### DIFF
--- a/Controllers/SummaryAndAudioController.php
+++ b/Controllers/SummaryAndAudioController.php
@@ -5,8 +5,6 @@ class FreshExtension_SummaryAndAudio_Controller extends Minz_ActionController
   public function summarizeAction()
   {
     $this->view->_layout(false);
-    // JSON - Set response header to JSON
-    header('Content-Type: application/json');
 
     $oai_url = FreshRSS_Context::$user_conf->oai_url;
     $oai_key = FreshRSS_Context::$user_conf->oai_key;
@@ -18,11 +16,12 @@ class FreshExtension_SummaryAndAudio_Controller extends Minz_ActionController
     $oai_prompt = $use_more ? $oai_prompt_more : $oai_prompt_base;
 
     if (
-      $this->isEmpty($oai_url)
-      || $this->isEmpty($oai_key)
-      || $this->isEmpty($oai_model)
-      || $this->isEmpty($oai_prompt)
+      $this->isEmpty($oai_url) ||
+      $this->isEmpty($oai_key) ||
+      $this->isEmpty($oai_model) ||
+      $this->isEmpty($oai_prompt)
     ) {
+      header('Content-Type: application/json');
       echo json_encode(array(
         'response' => array(
           'data' => 'missing config',
@@ -38,66 +37,115 @@ class FreshExtension_SummaryAndAudio_Controller extends Minz_ActionController
     $entry = $entry_dao->searchById($entry_id);
 
     if ($entry === null) {
+      header('Content-Type: application/json');
       echo json_encode(array('status' => 404));
       return;
     }
 
-    $content = $entry->content(); // Replace with article content
+    $content = $entry->content();
+    $markdownContent = $this->htmlToMarkdown($content);
 
-    // $oai_url
-    $oai_url = rtrim($oai_url, '/'); // Remove the trailing slash
-    // Ollama doesn't use versioned endpoints, so avoid appending /v1 for that provider
+    $oai_url = rtrim($oai_url, '/');
     if ($oai_provider !== 'ollama' && !preg_match('/\/v\d+\/?$/', $oai_url)) {
-        $oai_url .= '/v1'; // If there is no version information, add /v1
+      $oai_url .= '/v1';
     }
-    // Open AI Input
-    $successResponse = array(
-      'response' => array(
-        'data' => array(
-          // Determine whether the URL ends with a version. If it does, no version information is added. If not, /v1 is added by default.
-          "oai_url" => $oai_url . '/responses',
-          "oai_key" => $oai_key,
-          "model" => $oai_model,
-          "input" => [
-            [
-              "role" => "system",
-              "content" => $oai_prompt
-            ],
-            [
-              "role" => "user",
-              "content" => "input: \n" . $content,
-            ]
-          ],
-          "reasoning" => [ "effort" => "minimal" ],
-          "max_output_tokens" => 2048, // You can adjust the length of the summary as needed.
-          "temperature" => 1, // gpt-5-nano expects 1
-          "stream" => true
-      ),
-      'provider' => 'openai',
-      'error' => null
-      ),
-      'status' => 200
-    );
 
-    // Ollama API Input
-    if ($oai_provider === "ollama") {
-      $successResponse = array(
-        'response' => array(
-          'data' => array(
-            "oai_url" => rtrim($oai_url, '/') . '/api/generate',
-            "oai_key" => $oai_key,
-            "model" => $oai_model,
-            "system" => $oai_prompt,
-            "prompt" =>  $markdownContent,
-            "stream" => true,
-          ),
-          'provider' => 'ollama',
-          'error' => null
-        ),
-        'status' => 200
-      );
+    $headers = [
+      'Content-Type: application/json',
+      'Authorization: Bearer ' . $oai_key,
+    ];
+
+    if ($oai_provider === 'ollama') {
+      $payload = json_encode([
+        'model' => $oai_model,
+        'system' => $oai_prompt,
+        'prompt' => $markdownContent,
+        'stream' => true,
+      ]);
+      $summaryUrl = rtrim($oai_url, '/') . '/api/generate';
+    } else {
+      $payload = json_encode([
+        'model' => $oai_model,
+        'input' => [
+          [ 'role' => 'system', 'content' => $oai_prompt ],
+          [ 'role' => 'user', 'content' => "input: \n" . $markdownContent ],
+        ],
+        'reasoning' => [ 'effort' => 'minimal' ],
+        'max_output_tokens' => 2048,
+        'temperature' => 1,
+        'stream' => true,
+      ]);
+      $summaryUrl = $oai_url . '/responses';
     }
-    echo json_encode($successResponse);
+
+    header('X-Summary-Provider: ' . $oai_provider);
+
+    $headersSent = false;
+    $statusCode = 0;
+    $respContentType = '';
+    $errorBody = '';
+
+    $ch = curl_init($summaryUrl);
+    curl_setopt_array($ch, [
+      CURLOPT_POST => true,
+      CURLOPT_HTTPHEADER => $headers,
+      CURLOPT_POSTFIELDS => $payload,
+      CURLOPT_HEADERFUNCTION => function ($curl, $header) use (&$statusCode, &$respContentType) {
+        $len = strlen($header);
+        if (preg_match('#HTTP/\d+(?:\.\d+)?\s+(\d+)#', $header, $m)) {
+          $statusCode = (int)$m[1];
+        } elseif (stripos($header, 'Content-Type:') === 0) {
+          $respContentType = trim(substr($header, 13));
+        }
+        return $len;
+      },
+      CURLOPT_WRITEFUNCTION => function ($curl, $data) use (&$headersSent, &$statusCode, &$respContentType, &$errorBody) {
+        if (!$headersSent) {
+          if ($statusCode >= 200 && $statusCode < 300) {
+            $type = $respContentType ?: 'text/plain';
+            header('Content-Type: ' . $type);
+            header('Cache-Control: no-cache');
+          } else {
+            header('Content-Type: application/json', true, $statusCode ?: 500);
+          }
+          $headersSent = true;
+        }
+        if ($statusCode >= 200 && $statusCode < 300) {
+          echo $data;
+          if (function_exists('ob_flush')) {
+            @ob_flush();
+          }
+          flush();
+        } else {
+          $errorBody .= $data;
+        }
+        return strlen($data);
+      },
+    ]);
+
+    $result = curl_exec($ch);
+    if ($result === false && !$headersSent) {
+      $errorBody = curl_error($ch);
+    }
+    curl_close($ch);
+
+    if ($result === false || $statusCode < 200 || $statusCode >= 300) {
+      if (!$headersSent) {
+        header('Content-Type: application/json', true, $statusCode ?: 500);
+      }
+      $msg = 'Summary request failed';
+      $decoded = json_decode($errorBody, true);
+      if ($decoded && isset($decoded['error']['message'])) {
+        $msg = $decoded['error']['message'];
+      }
+      echo json_encode(array(
+        'response' => array(
+          'data' => '',
+          'error' => $msg,
+        ),
+        'status' => $statusCode ?: 500,
+      ));
+    }
     return;
   }
 

--- a/static/script.js
+++ b/static/script.js
@@ -89,41 +89,116 @@ async function summarizeButtonClick(target) {
 
   setOaiState(container, 1, t.preparingRequest, null);
 
-  // This is the address where PHP gets the parameters
   var url = target.dataset.request;
   var data = new URLSearchParams();
   data.append('ajax', 'true');
   data.append('_csrf', context.csrf);
 
   try {
-    const response = await axios.post(url, data, {
+    const response = await fetch(url, {
+      method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded'
-      }
+      },
+      body: data
     });
 
-    const xresp = response.data;
-    console.log(xresp);
-
-    if (response.status !== 200 || !xresp.response || !xresp.response.data) {
+    if (!response.ok) {
       throw new Error(t.requestFailed + ' (1)');
     }
 
-    if (xresp.response.error) {
-      setOaiState(container, 2, xresp.response.data, null);
+    const provider = response.headers.get('X-Summary-Provider') || 'openai';
+    setOaiState(container, 1, provider === 'ollama' ? t.pendingOllama : t.pendingOpenai, null);
+    await streamSummary(container, response, provider);
+  } catch (error) {
+    console.error(error);
+    setOaiState(container, 2, t.requestFailed + ' (2)', null);
+  }
+}
+
+async function streamSummary(container, response, provider) {
+  const t = container.dataset;
+  try {
+    setOaiState(container, 1, t.receivingAnswer, null);
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder('utf-8');
+    let text = '';
+    let buffer = '';
+    if (provider === 'ollama') {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          setOaiState(container, 0, 'finish', null);
+          break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        let endIndex;
+        while ((endIndex = buffer.indexOf('\n')) !== -1) {
+          const jsonString = buffer.slice(0, endIndex).trim();
+          buffer = buffer.slice(endIndex + 1);
+          if (!jsonString) continue;
+          try {
+            const json = JSON.parse(jsonString);
+            if (json.response) {
+              text += json.response;
+              setOaiState(container, 0, null, marked.parse(text));
+            }
+          } catch (e) {
+            console.error('Error parsing JSON:', e, 'Chunk:', jsonString);
+          }
+        }
+      }
     } else {
-      const oaiParams = xresp.response.data;
-      const oaiProvider = xresp.response.provider;
-      setOaiState(container, 1, oaiProvider === 'openai' ? t.pendingOpenai : t.pendingOllama, null);
-      if (oaiProvider === 'openai') {
-        await sendOpenAIRequest(container, oaiParams);
-      } else {
-        await sendOllamaRequest(container, oaiParams);
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          if (buffer.trim()) {
+            try {
+              const json = JSON.parse(buffer.trim());
+              if (json.output_text) {
+                text += json.output_text;
+                setOaiState(container, 0, null, marked.parse(text));
+              }
+            } catch (e) {
+              console.error('Error parsing final JSON:', e, 'Chunk:', buffer);
+              setOaiState(container, 2, t.requestFailed + ' (3)', null);
+            }
+          }
+          setOaiState(container, 0, 'finish', null);
+          break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        let parts = buffer.split(/\n\n/);
+        buffer = parts.pop();
+        for (let part of parts) {
+          const lines = part.trim().split('\n');
+          const dataLine = lines.find(l => l.startsWith('data:'));
+          if (!dataLine) continue;
+          let data = dataLine.slice(5).trim();
+          if (data === '[DONE]') {
+            setOaiState(container, 0, 'finish', null);
+            return;
+          }
+          try {
+            const json = JSON.parse(data);
+            if (json.type === 'response.completed') {
+              setOaiState(container, 0, 'finish', null);
+              return;
+            }
+            const delta = json.delta || json.output_text || '';
+            if (delta) {
+              text += delta;
+              setOaiState(container, 0, null, marked.parse(text));
+            }
+          } catch (e) {
+            console.error('Error parsing JSON:', e, 'Chunk:', data);
+          }
+        }
       }
     }
   } catch (error) {
     console.error(error);
-    setOaiState(container, 2, t.requestFailed + ' (2)', null);
+    setOaiState(container, 2, t.requestFailed + ' (4)', null);
   }
 }
 
@@ -419,135 +494,3 @@ async function ttsButtonClick(target, forceStop = false, preload = false) {
   }
 }
 
-async function sendOpenAIRequest(container, oaiParams) {
-  const t = container.dataset;
-  try {
-    let body = JSON.parse(JSON.stringify(oaiParams));
-    delete body['oai_url'];
-    delete body['oai_key'];
-    const response = await fetch(oaiParams.oai_url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${oaiParams.oai_key}`
-      },
-      body: JSON.stringify(body)
-    });
-
-    if (!response.ok) {
-      throw new Error(t.requestFailed + ' (3)');
-    }
-    setOaiState(container, 1, t.receivingAnswer, null);
-
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder('utf-8');
-    let text = '';
-    let buffer = '';
-
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        if (buffer.trim()) {
-          try {
-            const json = JSON.parse(buffer.trim());
-            if (json.output_text) {
-              text += json.output_text;
-              setOaiState(container, 0, null, marked.parse(text));
-            }
-          } catch (e) {
-            console.error('Error parsing final JSON:', e, 'Chunk:', buffer);
-            setOaiState(container, 2, t.requestFailed + ' (4)', null);
-          }
-        }
-        setOaiState(container, 0, 'finish', null);
-        break;
-      }
-      buffer += decoder.decode(value, { stream: true });
-
-      // Split buffer into Server-Sent Events
-      let parts = buffer.split(/\n\n/);
-      buffer = parts.pop();
-      for (let part of parts) {
-        const lines = part.trim().split('\n');
-        const dataLine = lines.find(l => l.startsWith('data:'));
-        if (!dataLine) continue;
-        let data = dataLine.slice(5).trim();
-        if (data === '[DONE]') {
-          setOaiState(container, 0, 'finish', null);
-          return;
-        }
-        try {
-          const json = JSON.parse(data);
-          if (json.type === 'response.completed') {
-            setOaiState(container, 0, 'finish', null);
-            return;
-          }
-          const delta = json.delta || json.output_text || '';
-          if (delta) {
-            text += delta;
-            setOaiState(container, 0, null, marked.parse(text));
-          }
-        } catch (e) {
-          console.error('Error parsing JSON:', e, 'Chunk:', data);
-        }
-      }
-    }
-  } catch (error) {
-    console.error(error);
-    setOaiState(container, 2, t.requestFailed + ' (5)', null);
-  }
-}
-
-
-async function sendOllamaRequest(container, oaiParams){
-  const t = container.dataset;
-  try {
-    const response = await fetch(oaiParams.oai_url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${oaiParams.oai_key}`
-      },
-      body: JSON.stringify(oaiParams)
-    });
-
-    if (!response.ok) {
-      throw new Error(t.requestFailed + ' (6)');
-    }
-    setOaiState(container, 1, t.receivingAnswer, null);
-
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder('utf-8');
-    let text = '';
-    let buffer = '';
-
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        setOaiState(container, 0, 'finish', null);
-        break;
-      }
-      buffer += decoder.decode(value, { stream: true });
-      // Try to process complete JSON objects from the buffer
-      let endIndex;
-      while ((endIndex = buffer.indexOf('\n')) !== -1) {
-        const jsonString = buffer.slice(0, endIndex).trim();
-        try {
-          if (jsonString) {
-            const json = JSON.parse(jsonString);
-            text += json.response
-            setOaiState(container, 0, null, marked.parse(text));
-          }
-        } catch (e) {
-          // If JSON parsing fails, output the error and keep the chunk for future attempts
-          console.error('Error parsing JSON:', e, 'Chunk:', jsonString);
-        }
-        // Remove the processed part from the buffer
-        buffer = buffer.slice(endIndex + 1); // +1 to remove the newline character
-      }
-    }
-  } catch (error) {
-    console.error(error);
-    setOaiState(container, 2, t.requestFailed + ' (7)', null);
-  }
-}

--- a/tests/SummaryAndAudioControllerTest.php
+++ b/tests/SummaryAndAudioControllerTest.php
@@ -25,10 +25,10 @@ class FreshRSS_Factory {
     }
 }
 
-// Set up configuration with a specific model name
+// Set up configuration with missing key to trigger config error
 FreshRSS_Context::$user_conf = (object) [
     'oai_url' => 'https://api.example.com',
-    'oai_key' => 'test-key',
+    'oai_key' => '', // missing on purpose
     'oai_model' => 'my-configured-model',
     'oai_prompt' => 'prompt',
     'oai_prompt_2' => 'prompt2',
@@ -49,15 +49,17 @@ $output = ob_get_clean();
 
 // Decode the JSON response
 $data = json_decode($output, true);
-$model = $data['response']['data']['model'] ?? null;
+$msg = $data['response']['data'] ?? null;
 
-// Simple assertion
-if ($model !== 'my-configured-model') {
-    echo "Model mismatch: expected my-configured-model, got {$model}\n";
+if ($msg !== 'missing config') {
+    echo "Expected missing config message, got {$msg}\n";
     exit(1);
 }
 
-echo "Model matches configuration\n";
+echo "SummarizeAction reports missing config as expected\n";
+
+// Reset configuration with valid key for TTS test
+FreshRSS_Context::$user_conf->oai_key = 'test-key';
 
 // Test fetchTtsParamsAction()
 ob_start();


### PR DESCRIPTION
## Summary
- Move summary generation to server-side to keep API keys private and proxy streaming responses
- Adapt client script to fetch summaries from server and handle provider-specific streaming
- Update tests for new summarize action behavior

## Testing
- `php tests/SummaryAndAudioControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c3dd8392b88321b92ef2b72cfd4558